### PR TITLE
Fix errors from `.kicad_pcb` file not being in git root #8 #9

### DIFF
--- a/plotPCB.py
+++ b/plotPCB.py
@@ -5,6 +5,7 @@ Kicad plot pcb file.
 Plot variety of svg files in plot directory
 '''
 
+import sys
 import pcbnew
 from pcbnew import *
 


### PR DESCRIPTION
* Fix failure to handle spaces in paths for linux
* Add a linux and MacOS specific `py` to handle spaces. 

This commit does not handle spaces for Windows.

There are two ways of escaping spaces in paths.
1. Escape with a backslash `\` [MacOS, Linux] (not possible in DOS)
2. Use double quotes around the entire path. [MacOS, Linux, and DOS)

While two (2) is possible, it's more difficult to implement because paths cannot simply be concatenated. The quoted string must be handled in each and every instance instead of passing down an escaped version. I'll have a go at that at some later point.