### PR TITLE
check changes in current dir only

### DIFF
--- a/kidiff_linux.py
+++ b/kidiff_linux.py
@@ -703,7 +703,7 @@ def getGitDiff(diff1, diff2, prjctName, prjctPath):
     artifact2 = diff2[:6]
 
     findDiff = 'cd ' + _escape_string(prjctPath) + ' && ' + gitProg + ' diff --name-only ' + \
-        artifact1 + ' ' + artifact2 + ' | ' + grepProg + ' .kicad_pcb'
+        artifact1 + ' ' + artifact2 + ' . | ' + grepProg + ' .kicad_pcb'
 
     changes = Popen(
         findDiff,


### PR DESCRIPTION
I'm using this in a git repo that contains multiple boards. I noticed that when any .kicad_pcb file changed, the check whether a particular .kicad_pcb file changed was always true, because the git command used listed diffs for the entire repo, rather than just the current directory.
I didn't test any other VCSs, so I don't know how they behave.