### PR TITLE
escape the project name, installation intructions for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,28 @@ There is an additional 'Text Diff' which is helpful for identifying specific are
 
 This was originally written as a bash script, this newer GUI version has been rewritten in Python3 and supports Git, SVN and Fossil as SCM tools. I have also removed many of the dependencies.
 
+## Mac Installation
+
+Installing tkinter on MacOS can be challening. Here is how it can be done on Big Sur (11.1)
+
+With homebrew and pyenv installed, run:
+
+```
+brew install tcl-tk
+export PATH="/usr/local/opt/tcl-tk/bin:$PATH"
+export LDFLAGS="-L/usr/local/opt/tcl-tk/lib"
+export CPPFLAGS="-I/usr/local/opt/tcl-tk/include"
+export PKG_CONFIG_PATH="/usr/local/opt/tcl-tk/lib/pkgconfig"
+export PYTHON_CONFIGURE_OPTS="--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
+LDFLAGS="-L$(xcrun --show-sdk-path)/usr/lib" pyenv install 3.8.6
+```
+
+Then before running the scripts, active this python version with:
+
+```
+pyenv shell 3.8.6
+```
+
 ## Instructions
 
 ### General

--- a/kidiff_cli.py
+++ b/kidiff_cli.py
@@ -101,7 +101,8 @@ def getGitPath(prjctName, prjctPath):
     stdout, stderr = gitRootProcess.communicate()
     gitRoot = stdout.decode('utf-8')
 
-    gitPathCmd = f"cd {_escape_string(gitRoot)} && {gitProg} ls-tree -r --name-only HEAD | {grepProg} -m 1 {prjctName}"
+    gitPathCmd = f"cd {_escape_string(gitRoot)} && {gitProg} ls-tree -r --name-only HEAD | {grepProg} -m 1 {_escape_string(prjctName)}"
+    print(gitPathCmd)
     gitPathProcess = Popen(
         gitPathCmd,
         shell=True,
@@ -150,7 +151,9 @@ def getGitDiff(diff1, diff2, prjctName, prjctPath, outputPath=None):
 
     gitPath = getGitPath(prjctName, _escape_string(prjctPath))
 
-    gitArtifact = [f"cd {_escape_string(prjctPath)} && {gitProg} show {art}:{gitPath} > {os.path.join(_escape_string(outd), prjctName)}" for art, outd in zip(artifact, outputDir)]
+    gitArtifact = [f"cd {_escape_string(prjctPath)} && {gitProg} show {art}:{gitPath} > {os.path.join(_escape_string(outd), _escape_string(prjctName))}" for art, outd in zip(artifact, outputDir)]
+
+    print(gitArtifact)
 
     ver = [Popen(
         gart,
@@ -324,10 +327,10 @@ def getFossilDiff(diff1, diff2, prjctName, prjctPath, outputPath=None):
     if not os.path.exists(outputDir2):
         os.makedirs(outputDir2)
 
-    fossilArtifact1 = 'cd ' + _escape_string(prjctPath) + ' && fossil cat ' + _escape_string(prjctPath) + '/' + prjctName + \
-        ' -r ' + artifact1 + ' > ' + outputDir1 + '/' + prjctName
-    fossilArtifact2 = 'cd ' + _escape_string(prjctPath) + ' && fossil cat ' + _escape_string(prjctPath) + '/' + prjctName + \
-        ' -r ' + artifact2 + ' > ' + outputDir2 + '/' + prjctName
+    fossilArtifact1 = 'cd ' + _escape_string(prjctPath) + ' && fossil cat ' + _escape_string(prjctPath) + '/' + _escape_string(prjctName) + \
+        ' -r ' + artifact1 + ' > ' + outputDir1 + '/' + _escape_string(prjctName)
+    fossilArtifact2 = 'cd ' + _escape_string(prjctPath) + ' && fossil cat ' + _escape_string(prjctPath) + '/' + _escape_string(prjctName) + \
+        ' -r ' + artifact2 + ' > ' + outputDir2 + '/' + _escape_string(prjctName)
 
     fossilInfo1 = 'cd ' + _escape_string(prjctPath) + ' && fossil info ' + artifact1
     fossilInfo2 = 'cd ' + _escape_string(prjctPath) + ' && fossil info ' + artifact2
@@ -1014,6 +1017,8 @@ if __name__ == "__main__":
 
         print(f"Commit1 {d1}")
         print(f"Commit2 {d2}")
+        print(f"prjctName {prjctName}")
+        print(f"prjctPath {prjctPath}")
 
         if scm == 'git':
             getDiff = getGitDiff

--- a/kidiff_html.py
+++ b/kidiff_html.py
@@ -121,8 +121,8 @@ indexHead = '''
 outfile = '''
 <div class="responsive">
   <div class="gallery">
-    <a target="_blank" href=../{diff1}/{layername}>
-    <a href=./tryptych/{prj}-{layer}.html> <img class="{layer}" src=../{diff1}/{layername} height="200"> </a>
+    <a target="_blank" href="../{diff1}/{layername}">
+    <a href="./tryptych/{prj}-{layer}.html"> <img class="{layer}" src="../{diff1}/{layername}" height="200"> </a>
     </a>
     <div class="desc">{layer}</div>
   </div>


### PR DESCRIPTION
- fixed a problem w/ project names w/ spaces
- added installation instructions for the latest macos