### PR TITLE
Fix outputDir in get_boards

### DIFF
--- a/scms/git.py
+++ b/scms/git.py
@@ -56,8 +56,8 @@ class scm(generic_scm):
             print("\nThere is no difference in .kicad_pcb file in selected commits")
             sys.exit()
 
-        outputDir1 = os.path.join(prjctPath, settings.plotDir, artifact1)
-        outputDir2 = os.path.join(prjctPath, settings.plotDir, artifact2)
+        outputDir1 = os.path.join(prjctPath, settings.plotDir, kicad_project_path, artifact1)
+        outputDir2 = os.path.join(prjctPath, settings.plotDir, kicad_project_path, artifact2)
 
         if not os.path.exists(outputDir1):
             os.makedirs(outputDir1)


### PR DESCRIPTION
First off, great project!

I was running into problems when using kidiff with git, as the `.kicad_pcb` files were not copied to the expected folder. I think the way the different SCM modules handle the project paths differently and it seems to me, that `git.py` was not making use of `kicad_project_path` as it should (compared to svn - the issue might also extend to fossil). 

With the proposed changes, I got things to work in my case (git) :-)