### PR TITLE
Generate duplicated images with the custom layer name from the board

### DIFF
--- a/plotPCB.py
+++ b/plotPCB.py
@@ -66,31 +66,6 @@ def processBoard(boardName, plotDir, quiet):
     popt.SetExcludeEdgeLayer(False)
     popt.SetUseAuxOrigin(True)
 
-    # layers = [
-    #     ("F_Cu", pcbnew.F_Cu, "Top layer"),
-    #     ("B_Cu", pcbnew.B_Cu, "Bottom layer"),
-    #     ("B_Paste", pcbnew.B_Paste, "Paste bottom"),
-    #     ("F_Paste", pcbnew.F_Paste, "Paste top"),
-    #     ("F_SilkS", pcbnew.F_SilkS, "Silk top"),
-    #     ("B_SilkS", pcbnew.B_SilkS, "Silk top"),
-    #     ("B_Mask", pcbnew.B_Mask, "Mask bottom"),
-    #     ("F_Mask", pcbnew.F_Mask, "Mask top"),
-    #     ("Edge_Cuts", pcbnew.Edge_Cuts, "Edges"),
-    #     ("Margin", pcbnew.Margin, "Margin"),
-    #     ("In1_Cu", pcbnew.In1_Cu, "Inner1"),
-    #     ("In2_Cu", pcbnew.In2_Cu, "Inner2"),
-    #     ("Dwgs_User", pcbnew.Dwgs_User, "Dwgs_User"),
-    #     ("Cmts_User", pcbnew.Cmts_User, "Comments_User"),
-    #     ("Eco1_User", pcbnew.Eco1_User, "ECO1"),
-    #     ("Eco2_User", pcbnew.Eco2_User, "ECO2"),
-    #     ("B_Fab", pcbnew.B_Fab, "Fab bottom"),
-    #     ("F_Fab", pcbnew.F_Fab, "Fab top"),
-    #     ("B_Adhes", pcbnew.B_Adhes, "Adhesive bottom"),
-    #     ("F_Adhes", pcbnew.F_Adhes, "Adhesive top"),
-    #     ("B_CrtYd", pcbnew.B_CrtYd, "Courtyard bottom"),
-    #     ("F_CrtYd", pcbnew.F_CrtYd, "Courtyard top"),
-    # ]
-
     layers = [
         ("F_Cu",      F_Cu,      "Top copper"),
         ("In1_Cu",    In1_Cu,    "Inner1 copper"),

--- a/plotPCB.py
+++ b/plotPCB.py
@@ -121,7 +121,9 @@ def processBoard(boardName, plotDir, quiet):
     for layer_info in layers:
         pctl.SetLayer(layer_info[1])
         pctl.OpenPlotfile(layer_info[0], PLOT_FORMAT_SVG, layer_info[2])
-        pctl.OpenPlotfile(board.GetLayerName(layer_info[1]), PLOT_FORMAT_SVG, layer_info[2])
+        layer_name = board.GetLayerName(layer_info[1]).replace(".", "_")
+        if layer_info[0] != layer_name:
+            pctl.OpenPlotfile(layer_name, PLOT_FORMAT_SVG, layer_info[2])
         pctl.PlotLayer()
 
     return (boardxl, boardyl, boardwidth, boardheight)

--- a/plotPCB.py
+++ b/plotPCB.py
@@ -121,6 +121,7 @@ def processBoard(boardName, plotDir, quiet):
     for layer_info in layers:
         pctl.SetLayer(layer_info[1])
         pctl.OpenPlotfile(layer_info[0], PLOT_FORMAT_SVG, layer_info[2])
+        pctl.OpenPlotfile(board.GetLayerName(layer_info[1]), PLOT_FORMAT_SVG, layer_info[2])
         pctl.PlotLayer()
 
     return (boardxl, boardyl, boardwidth, boardheight)


### PR DESCRIPTION
This PR creates extra images with custom layer names. This is a step towards the generation of a dynamic layer set.  
These extra images are going to be used in the new kdiff mockup too.