### PR TITLE
Add support to compare local not committed changes

### DIFF
--- a/kidiff
+++ b/kidiff
@@ -135,14 +135,23 @@ def makeSVG(d1, d2, board_file, kicad_project_path, prjctPath):
     print("")
     print("Generating board files")
 
-    d1 = d1[:7]
-    d2 = d2[:7]
+    if not d1 == board_file:
+        d1 = d1[:7]
+    else:
+        d1 = "local"
 
     d1SVG = os.path.join(prjctPath, settings.plotDir, kicad_project_path, d1)
+
+    if not d2 == board_file:
+        d2 = d2[:7]
+    else:
+        d2 = "local"
+
     d2SVG = os.path.join(prjctPath, settings.plotDir, kicad_project_path, d2)
 
     Diff1 = os.path.join(d1SVG, board_file)
     Diff2 = os.path.join(d2SVG, board_file)
+
     print("")
     print("Setting paths")
     print("Diff1: ", Diff1)

--- a/scms/fossil.py
+++ b/scms/fossil.py
@@ -1,7 +1,10 @@
 
+import datetime
 import os
-import sys
 import settings
+import shutil
+import sys
+import time
 from scms.generic import scm as generic_scm
 
 class scm(generic_scm):
@@ -10,34 +13,41 @@ class scm(generic_scm):
         '''Given two Fossil artifacts, write out two kicad_pcb files to their respective
         directories (named after the artifacts). Returns the date and time of both commits'''
 
-        artifact1 = diff1[:6]
-        artifact2 = diff2[:6]
+        if not diff1 == prjctName:
+            artifact1 = diff1[:6]
+        else:
+            artifact1 = "local"
+
+        if not diff2 == prjctName:
+            artifact2 = diff2[:6]
+        else:
+            artifact2 = "local"
 
         # Using this to fix the path when there is no subproject
         prj_path = kicad_project_path + '/'
         if kicad_project_path == '.':
             prj_path = ''
 
-        cmd = ['fossil', 'diff', '--brief', '-r',
-               artifact1, '--to', artifact2]
+        if (not diff1 == prjctName) and (not diff2 == prjctName):
 
-        print("")
-        print("Getting Boards")
-        print(cmd)
+            cmd = ['fossil', 'diff', '--brief', '-r', artifact1, '--to', artifact2]
 
-        stdout, stderr = settings.run_cmd(prjctPath, cmd)
-        changed = '.kicad_pcb' in stdout
+            print("")
+            print("Getting Boards")
+            print(cmd)
 
-        if not changed:
-            print("\nThere is no difference in .kicad_pcb file in selected commits")
-            sys.exit()
+            stdout, stderr = settings.run_cmd(prjctPath, cmd)
+            changed = '.kicad_pcb' in stdout
+
+            if not changed:
+                print("\nThere is no difference in .kicad_pcb file in selected commits")
+
 
         outputDir1 = os.path.join(prjctPath, settings.plotDir, kicad_project_path, artifact1)
-        outputDir2 = os.path.join(prjctPath, settings.plotDir, kicad_project_path, artifact2)
-
         if not os.path.exists(outputDir1):
             os.makedirs(outputDir1)
 
+        outputDir2 = os.path.join(prjctPath, settings.plotDir, kicad_project_path, artifact2)
         if not os.path.exists(outputDir2):
             os.makedirs(outputDir2)
 
@@ -46,38 +56,65 @@ class scm(generic_scm):
         print(outputDir1)
         print(outputDir2)
 
-        # gitPath = get_board_path(prjctName, prjctPath)
-        gitPath = prj_path + prjctName
-
-        fossilArtifact1 = ['fossil', 'cat', settings.escape_string(prjctPath) + gitPath,
-                           '-r', artifact1]
-        fossilArtifact2 = ['fossil', 'cat', settings.escape_string(prjctPath) + gitPath,
-                           '-r', artifact2]
+        fossilPath = prj_path + prjctName
 
         print("")
-        print("Setting artifact paths")
-        print(fossilArtifact1)
-        print(fossilArtifact2)
+        print("Setting artifacts paths")
+        print("fossilPath   :", fossilPath)
 
-        fossilDateTime1 = ['fossil', 'info', artifact1]
-        fossilDateTime2 = ['fossil', 'info', artifact2]
+        if not diff1 == prjctName:
+            fossilArtifact1 = [
+                'fossil', 'cat', prjctPath + fossilPath, '-r', artifact1]
+            print("Fossil artifact2: ", fossilArtifact1)
+        else:
+            print("Fossil artifact2: ", diff1)
+
+        if not diff2 == prjctName:
+            fossilArtifact2 = [
+                'fossil', 'cat', prjctPath + fossilPath, '-r', artifact2]
+            print("Fossil artifact2: ", fossilArtifact2)
+        else:
+            print("Fossil artifact2: ", diff2)
+
 
         print("")
         print("Checking datetime")
-        print(fossilDateTime1)
-        print(fossilDateTime2)
+        if not diff1 == prjctName:
+            fossilDateTime1 = ['fossil', 'info', artifact1]
+            print(fossilDateTime1)
+        else:
+            artifact1 = prjctName
+            modTimesinceEpoc = os.path.getmtime(prjctName)
+            dateDiff1 = time.strftime('%Y-%m-%d', time.localtime(modTimesinceEpoc))
+            timeDiff1 = time.strftime('%H:%M:%S', time.localtime(modTimesinceEpoc))
 
-        stdout, stderr = settings.run_cmd(prjctPath, fossilArtifact1)
-        with open(os.path.join(outputDir1, prjctName), 'w') as f:
-            f.write(stdout)
-        dateTime, _ = settings.run_cmd(prjctPath, fossilDateTime1)
-        uuid, _, _, _, _, _, _, _, _, artifactRef, dateDiff1, timeDiff1, *junk1 = dateTime.split(" ")
+        if not diff2 == prjctName:
+            fossilDateTime2 = ['fossil', 'info', artifact2]
+            print(fossilDateTime2)
+        else:
+            artifact2 = prjctName
+            modTimesinceEpoc = os.path.getmtime(prjctName)
+            dateDiff2 = time.strftime('%Y-%m-%d', time.localtime(modTimesinceEpoc))
+            timeDiff2 = time.strftime('%H:%M:%S', time.localtime(modTimesinceEpoc))
 
-        stdout, stderr = settings.run_cmd(prjctPath, fossilArtifact2)
-        with open(os.path.join(outputDir2, prjctName), 'w') as f:
-            f.write(stdout)
-        dateTime, _ = settings.run_cmd(prjctPath, fossilDateTime2)
-        uuid, _, _, _, _, _, _, _, _, artifactRef, dateDiff2, timeDiff2, *junk2 = dateTime.split(" ")
+        if not diff1 == prjctName:
+            stdout, stderr = settings.run_cmd(prjctPath, fossilArtifact1)
+            with open(os.path.join(outputDir1, prjctName), 'w') as f:
+                f.write(stdout)
+            dateTime, _ = settings.run_cmd(prjctPath, fossilDateTime1)
+            uuid, _, _, _, _, _, _, _, _, artifactRef, dateDiff1, timeDiff1, *junk1 = dateTime.split(" ")
+        else:
+            shutil.copyfile(prjctName, os.path.join(outputDir1, prjctName))
+
+        if not diff2 == prjctName:
+            stdout, stderr = settings.run_cmd(prjctPath, fossilArtifact2)
+            with open(os.path.join(outputDir2, prjctName), 'w') as f:
+                f.write(stdout)
+            dateTime, _ = settings.run_cmd(prjctPath, fossilDateTime2)
+            uuid, _, _, _, _, _, _, _, _, artifactRef, dateDiff2, timeDiff2, *junk2 = dateTime.split(" ")
+        else:
+            shutil.copyfile(prjctName, os.path.join(outputDir2, prjctName))
+
 
         dateTime = dateDiff1 + " " + timeDiff1 + " " + dateDiff2 + " " + timeDiff2
 
@@ -94,7 +131,7 @@ class scm(generic_scm):
         print(cmd)
 
         stdout, stderr = settings.run_cmd(prjctPath, cmd)
-        artifacts = [a.replace(' ', ' | ', 4) for a in stdout.splitlines()]
+        artifacts = [board_file] + [a.replace(' ', ' | ', 4) for a in stdout.splitlines()]
 
         return artifacts
 

--- a/scms/git.py
+++ b/scms/git.py
@@ -1,5 +1,7 @@
 
+import time
 import os
+import shutil
 import sys
 import settings
 from scms.generic import scm as generic_scm
@@ -10,72 +12,105 @@ class scm(generic_scm):
         '''Given two git artifacts, write out two kicad_pcb files to their respective
         directories (named after the artifact). Returns the date and time of both commits'''
 
-        artifact1 = diff1[:7]
-        artifact2 = diff2[:7]
+        if not diff1 == prjctName:
+            artifact1 = diff1[:7]
+        else:
+            artifact1 = "local"
+
+        if not diff2 == prjctName:
+            artifact2 = diff2[:7]
+        else:
+            artifact2 = "local"
 
         # Using this to fix the path when there is no subproject
         prj_path = kicad_project_path + '/'
         if kicad_project_path == '.':
             prj_path = ''
 
-        cmd = ['git', 'diff', '--name-only', artifact1, artifact2, '.']
+        if (not diff1 == prjctName) and (not diff2 == prjctName):
+            cmd = ['git', 'diff', '--name-only', artifact1, artifact2, '.']
 
-        print("")
-        print("Getting boards")
-        print(cmd)
+            print("")
+            print("Getting boards")
+            print(cmd)
 
-        stdout, stderr = settings.run_cmd(prjctPath, cmd)
-        changed = (prj_path + prjctName) in stdout
+            stdout, stderr = settings.run_cmd(prjctPath, cmd)
+            changed = (prj_path + prjctName) in stdout
 
-        if not changed:
-            print("\nThere is no difference in .kicad_pcb file in selected commits")
-            sys.exit()
+            if not changed:
+                print("\nThere is no difference in .kicad_pcb file in selected commits")
 
         outputDir1 = os.path.join(prjctPath, settings.plotDir, kicad_project_path, artifact1)
-        outputDir2 = os.path.join(prjctPath, settings.plotDir, kicad_project_path, artifact2)
-
         if not os.path.exists(outputDir1):
             os.makedirs(outputDir1)
 
+        outputDir2 = os.path.join(prjctPath, settings.plotDir, kicad_project_path, artifact2)
         if not os.path.exists(outputDir2):
             os.makedirs(outputDir2)
 
-
         gitPath = prj_path + prjctName
 
-        gitArtifact1 = ['git', 'show', artifact1 + ':' + gitPath]
-        gitArtifact2 = ['git', 'show', artifact2 + ':' + gitPath]
-
         print("")
-        print("Get artifacts")
+        print("Setting artifacts paths")
         print("gitPath      :", gitPath)
-        print("Git artifact1: ", gitArtifact1)
-        print("Git artifact2: ", gitArtifact2)
 
-        stdout, stderr = settings.run_cmd(prjctPath, gitArtifact1)
-        with open(os.path.join(outputDir1, prjctName), 'w') as fout1:
-            fout1.write(stdout)
-        stdout, stderr = settings.run_cmd(prjctPath, gitArtifact2)
-        with open(os.path.join(outputDir2, prjctName), 'w') as fout2:
-            fout2.write(stdout)
-        gitDateTime1 = ['git', 'show', '-s', '--format="%ci"', artifact1]
-        gitDateTime2 = ['git', 'show', '-s', '--format="%ci"', artifact2]
+        if not diff1 == prjctName:
+            gitArtifact1 = ['git', 'show', artifact1 + ':' + gitPath]
+            print("Git artifact1: ", gitArtifact1)
+        else:
+            print("Git artifact1: ", diff1)
+
+        if not diff2 == prjctName:
+            gitArtifact2 = ['git', 'show', artifact2 + ':' + gitPath]
+            print("Git artifact2: ", gitArtifact2)
+        else:
+            print("Git artifact2: ", diff2)
+
+        if not diff1 == prjctName:
+            stdout, stderr = settings.run_cmd(prjctPath, gitArtifact1)
+            with open(os.path.join(outputDir1, prjctName), 'w') as fout1:
+                fout1.write(stdout)
+        else:
+            shutil.copyfile(prjctName, os.path.join(outputDir1, prjctName))
+
+
+        if not diff2 == prjctName:
+            stdout, stderr = settings.run_cmd(prjctPath, gitArtifact2)
+            with open(os.path.join(outputDir2, prjctName), 'w') as fout2:
+                fout2.write(stdout)
+        else:
+            shutil.copyfile(prjctName, os.path.join(outputDir1, prjctName))
 
         print("")
         print("Check datetime")
-        print(gitDateTime1)
-        print(gitDateTime2)
 
-        stdout, stderr = settings.run_cmd(prjctPath, gitDateTime1)
-        dateTime1 = stdout
-        date1, time1, UTC = dateTime1.split(' ')
+        if not diff1 == prjctName:
+            gitDateTime1 = ['git', 'show', '-s', '--format="%ci"', artifact1]
+            print(gitDateTime1)
 
-        stdout, stderr = settings.run_cmd(prjctPath, gitDateTime2)
-        dateTime2 = stdout
-        date2, time2, UTC = dateTime2.split(' ')
+        if not diff2 == prjctName:
+            gitDateTime2 = ['git', 'show', '-s', '--format="%ci"', artifact2]
+            print(gitDateTime2)
 
-        time1 = date1 + " " + time1
-        time2 = date2 + " " + time2
+        if not diff1 == prjctName:
+            stdout, stderr = settings.run_cmd(prjctPath, gitDateTime1)
+            dateTime1 = stdout
+            date1, time1, UTC = dateTime1.split(' ')
+            time1 = date1 + " " + time1
+        else:
+            artifact1 = prjctName
+            modTimesinceEpoc = os.path.getmtime(prjctName)
+            time1 = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(modTimesinceEpoc))
+
+        if not diff2 == prjctName:
+            stdout, stderr = settings.run_cmd(prjctPath, gitDateTime2)
+            dateTime2 = stdout
+            date2, time2, UTC = dateTime2.split(' ')
+            time2 = date2 + " " + time2
+        else:
+            artifact2 = prjctName
+            modTimesinceEpoc = os.path.getmtime(prjctName)
+            time2 = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(modTimesinceEpoc))
 
         return artifact1, artifact2, time1 + " " + time2
 
@@ -87,7 +122,7 @@ class scm(generic_scm):
 
         stdout, _ = settings.run_cmd(prjctPath, cmd)
 
-        artifacts = stdout.splitlines()
+        artifacts = [board_file] + stdout.splitlines()
 
         return artifacts
 


### PR DESCRIPTION
This PR adds the current local changes in the commits list allowing it to be compared without having to commit changes.

In this way, the `.kicad_pcb` is being added on top of the lists
![image](https://user-images.githubusercontent.com/1277920/123500599-98bb4880-d615-11eb-870f-169ced810824.png)

This also fixes an issue we created on fossil when removing the `space_escape` workaround. @jnavila 

This PR was tested with Git and Fossil, unfortunately, I don't have SVN setup anymore to test.  