### PR TITLE
Python requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,18 @@ The diff output can be scrolled and zoomed in and out for closer inspection. The
 
 ## Instructions
 
-### General
-- Ensure that you have Python3 installed. Why? https://www.pythonclock.org 
-- The terminal should give you some useful information on progress. Please include a copy of this if you have any issues.
-- Hit `Ctrl+C` to terminate the webserver.
+### Dependencies
 
+- Ensure that you have Python3 installed. Why? https://www.pythonclock.org 
+- Python Libraries from Kicad 5.*
+- For python dependencies check the `requitements.txt`
+
+To install KiCad-Diff dependencies:
+
+```
+cd KiCad-Diff
+pip3 install -r requirements.txt
+```
 
 ## Usage
 
@@ -26,6 +33,8 @@ This can be done easely with:
 cd KiCad-Diff
 source env.sh
 ```
+
+The terminal should give you some useful information on progress. Please include a copy of the terminal output if you have any issues.
 
 ### Comandline help
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pygubu==0.10.5
+python_dateutil==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
-pygubu==0.10.5
+AwesomeTkinter==2021.1.7
+dateutils==0.6.12
+Pillow==8.1.2
+pygubu==0.10.7
 python_dateutil==2.8.1
+pytz==2021.1
+six==1.15.0


### PR DESCRIPTION
This was closed by mistake by me. I thought it was merged. 
It gives the user the requirements.txt file to install dependencies with pip

Usage
```
pip3 install -r requirement.txt
```