### PR TITLE
Add quotes around URLs in HTML attributes

### DIFF
--- a/assets/html_data.py
+++ b/assets/html_data.py
@@ -119,9 +119,9 @@ indexHead = '''
 outfile = '''
 <div class="responsive">
     <div class="gallery">
-        <a target="_blank" href=../{diff1}/{layername}>
-            <a href=./triptych/{prj}-{layer}.html>
-                <img class="{layer}" src=../{diff1}/{layername} height="200">
+        <a target="_blank" href="../{diff1}/{layername}">
+            <a href="./triptych/{prj}-{layer}.html">
+                <img class="{layer}" src="../{diff1}/{layername}" height="200">
             </a>
         </a>
         <div class="desc">{layer}</div>


### PR DESCRIPTION
Currently any filenames with spaces (potentially other characters too) will result in invalid HTML, for example:

```html
<div class="responsive">
    <div class="gallery">
        <a target="_blank" href=../local/GI - Charging Board - with USB Host-In4_Cu.svg>
            <a href=./triptych/GI - Charging Board - with USB Host-In4_Cu.html>
                <img class="In4_Cu" src=../local/GI - Charging Board - with USB Host-In4_Cu.svg height="200">
            </a>
        </a>
        <div class="desc">In4_Cu</div>
    </div>
</div>
```
This PR will avoid this by adding quotes, although it is not a complete fix as any filenames that contain double quotes or backslashes will still have problems.