### PR TITLE
Adds a parameter to allow changing output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The terminal should give you some useful information on progress. Please include
 ### Commandline help
 
 ```
-➜ ./kidiff -h
-usage: kidiff [-h] [-a COMMIT1] [-b COMMIT2] [-g] [-s SCM] [-d DISPLAY] [-p PORT] [-w] [-v] [PCB_PATH]
+➜ kidiff -h
+usage: kidiff [-h] [-a COMMIT1_HASH] [-b COMMIT2_HASH] [-g] [-s SCM] [-d DISPLAY] [-p PORT] [-w] [-v] [-o OUTPUT_DIR] [PCB_PATH]
 
 Kicad PCB visual diffs.
 
@@ -49,10 +49,10 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -a COMMIT1, --commit1 COMMIT1
-                        Commit 1
-  -b COMMIT2, --commit2 COMMIT2
-                        Commit 2
+  -a COMMIT1_HASH, --commit1-hash COMMIT1_HASH
+                        Commit 1 hash
+  -b COMMIT2_HASH, --commit2-hash COMMIT2_HASH
+                        Commit 2 hash
   -g, --gui             Use gui
   -s SCM, --scm SCM     Select SCM (git, svn, fossil)
   -d DISPLAY, --display DISPLAY
@@ -61,6 +61,8 @@ optional arguments:
   -w, --webserver-disable
                         Does not execute webserver (just generate images)
   -v, --verbose         Increase verbosity (-vvv)
+  -o OUTPUT_DIR, --output-dir OUTPUT_DIR
+                        Set output directory. Default is 'kidiff'.
 
 ```
 
@@ -73,7 +75,7 @@ kidiff led_test.kicad_pcb
 # Forcing an specific SCM when more than one is available (Precedence: Git > Fossil > SVN)
 kidiff led_test.kicad_pcb --scm fossil
 
-# With a Git repo, passing Commit 1 and 2 on the command line
+# With a SVN repo, passing commit 1 and 2 on the command line
 kidiff led_test.kicad_pcb -a r1 -b r3
 
 ```

--- a/env-nightly.sh
+++ b/env-nightly.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Python modules for the new PCBNew
+# Setup for Kicad-Nigtly (>= 5.99) python modules
 
 case ${OSTYPE} in
 
@@ -18,6 +18,4 @@ case ${OSTYPE} in
 
 esac
 
-
-# Binaries
-export PATH=$(pwd):${PATH}
+source ./env.sh

--- a/env.sh
+++ b/env.sh
@@ -3,6 +3,8 @@
 # Usage: Source this file as:
 # $> source ./env.sh
 
+export TK_SILENCE_DEPRECATION=1
+
 readlink_osx()
 {
 	target_file="$1"

--- a/env.sh
+++ b/env.sh
@@ -43,4 +43,4 @@ readlink_()
 script=$(readlink_ "$0")
 script_path=$(dirname "$script")
 
-export PATH="${script_path}:$PATH"
+export PATH="${script_path}":$PATH

--- a/env.sh
+++ b/env.sh
@@ -3,4 +3,44 @@
 # Usage: Source this file as:
 # $> source ./env.sh
 
-export PATH=$(pwd):${PATH}
+readlink_osx()
+{
+	target_file="$1"
+	dir_name=$(dirname "$target_file")
+
+	cd "${dir_name}" || exit
+	target_file=$(basename "$target_file")
+
+	# Iterate down a (possible) chain of symlinks
+	while [ -L "$target_file" ]
+	do
+		target_file=$(readlink "$target_file")
+		cd "$(dirname "$target_file")" || exit
+		target_file=$(basename "$target_file")
+	done
+
+	# Compute the canonicalized name by finding the physical path
+	# for the directory we're in and appending the target file.
+	phys_dir=$(pwd -P)
+
+	result="$phys_dir/$target_file"
+
+	echo "$result"
+}
+
+readlink_()
+{
+	case $OSTYPE in
+		darwin*)
+			readlink_osx "$1"
+			;;
+		*)
+			readlink -f "$1"
+			;;
+	esac
+}
+
+script=$(readlink_ "$0")
+script_path=$(dirname "$script")
+
+export PATH="${script_path}:$PATH"

--- a/kidiff
+++ b/kidiff
@@ -73,7 +73,7 @@ def select_project_gui(display):
     return (repo_path, kicad_pcb)
 
 
-def check_project_scms(prjct_path):
+def get_project_scms(repo_path):
     """Determines which SCM is being used by the project.
     Current order of priority: Git > Fossil > SVN
     """
@@ -82,13 +82,13 @@ def check_project_scms(prjct_path):
 
     if is_tool_available("git"):
         cmd = ["git", "status"]
-        stdout, stderr = settings.run_cmd(prjct_path, cmd)
+        stdout, stderr = settings.run_cmd(repo_path, cmd)
         if (stdout != "") & (stderr == ""):
             scms.append("git")
 
     if is_tool_available("fossil"):
         cmd = ["fossil", "status"]
-        stdout, stderr = settings.run_cmd(prjct_path, cmd)
+        stdout, stderr = settings.run_cmd(repo_path, cmd)
         if stdout != "":
             scms.append("fossil")
 
@@ -96,90 +96,80 @@ def check_project_scms(prjct_path):
         cmd = [
             "svn",
             "log",
-        ]  # | perl -l4svn log0pe "s/^-+/\n/"'.format(prjct_path=prjct_path)
-        stdout, stderr = settings.run_cmd(prjct_path, cmd)
+        ]  # | perl -l4svn log0pe "s/^-+/\n/"'.format(repo_path=repo_path)
+        stdout, stderr = settings.run_cmd(repo_path, cmd)
         if (stdout != "") & (stderr == ""):
             scms.append("svn")
 
     return scms
 
 
-def make_svg(d1, d2, board_file, kicad_project_path, prjct_path):
+def make_svg(repo_path, kicad_project_dir, board_filename, commit1, commit2):
     """Hands off required .kicad_pcb files to "plotpcb"
     and generate .svg files. Routine is quick so all
     layers are plotted to svg."""
 
-    print("")
-    print("Generating board files")
+    commit1_hash = "local"
+    commit2_hash = "local"
 
-    if not d1 == board_file:
-        d1 = d1[:7]
-    else:
-        d1 = "local"
+    if not commit1 == board_filename:
+        commit1_hash = commit1[:7]
 
-    d1_svg = os.path.join(prjct_path, settings.output_dir, kicad_project_path, d1)
+    if not commit2 == board_filename:
+        commit2_hash = commit2[:7]
 
-    if not d2 == board_file:
-        d2 = d2[:7]
-    else:
-        d2 = "local"
+    # Output folder
+    commit1_output_path = os.path.join(settings.output_dir, commit1_hash)
+    commit2_output_path = os.path.join(settings.output_dir, commit2_hash)
 
-    d2_svg = os.path.join(prjct_path, settings.output_dir, kicad_project_path, d2)
+    # Commit's board recovered from SCM history
+    commit1_board_path = os.path.join(commit1_output_path, board_filename)
+    commit2_board_path = os.path.join(commit2_output_path, board_filename)
 
-    diff1 = os.path.join(d1_svg, board_file)
-    diff2 = os.path.join(d2_svg, board_file)
+    if not os.path.exists(commit1_output_path):
+        os.makedirs(commit1_output_path)
 
-    print("")
-    print("Setting paths")
-    print("diff1: ", diff1)
-    print("diff2: ", diff2)
+    if not os.path.exists(commit2_output_path):
+        os.makedirs(commit2_output_path)
 
-    if not os.path.exists(d1_svg):
-        os.makedirs(d1_svg)
+    plot1_cmd = [settings.plot_prog, commit1_board_path] #, "-o", commit1_output_path]
+    plot2_cmd = [settings.plot_prog, commit2_board_path] #, "-o", commit2_output_path]
 
-    if not os.path.exists(d2_svg):
-        os.makedirs(d2_svg)
+    stdout, stderr = settings.run_cmd(os.path.join(repo_path, kicad_project_dir), plot1_cmd)
+    plot1_stdout = stdout.splitlines()
+    plot1_stderr = stderr
 
-    plot1_cmd = [settings.plot_prog, diff1, "-o", d1_svg]
-    plot2_cmd = [settings.plot_prog, diff2, "-o", d2_svg]
-
-    print("")
-    print("Plot Commands:")
-    print(' '.join(plot1_cmd))
-    print(' '.join(plot2_cmd))
-
-    stdout, stderr = settings.run_cmd(prjct_path, plot1_cmd)
-    plot_dims1 = stdout.splitlines()
-    errors = stderr
-
-    if errors != "":
+    if plot1_stderr != "":
         print(stdout)
-        print("Plot1 error: " + errors)
+        print("Plot1 error: " + plot1_stderr)
         exit(1)
 
-    stdout, stderr = settings.run_cmd(prjct_path, plot2_cmd)
-    plot_dims2 = stdout.splitlines()
-    errors = stderr
+    stdout, stderr = settings.run_cmd(os.path.join(repo_path, kicad_project_dir), plot2_cmd)
+    plot2_stdout = stdout.splitlines()
+    plot2_stderr = stderr
 
-    if errors != "":
+    if plot2_stderr != "":
         print(stdout)
-        print("Plot2 error: " + errors)
+        print("Plot2 error: " + plot2_stderr)
         exit(1)
 
-    if not plot_dims1 or not plot_dims2:
+    if not plot1_stdout or not plot2_stdout:
         print("ERROR: Something happened with plotpcb")
         exit(1)
 
-    return (d1, d2, plot_dims1[0], plot_dims2[0])
+    # exit(1)
+
+    return commit1_hash, commit2_hash
 
 
-def make_support_files(board_file, kicad_project_path, prjct_path, svg_dir1, svg_dir2):
+
+def generate_assets(repo_path, kicad_project_dir, board_filename, output_dir1, output_dir2):
     """
     Setup web directories for output
     """
 
     web_dir = os.path.join(
-        prjct_path, settings.output_dir, kicad_project_path, settings.web_dir
+        settings.output_dir, settings.web_dir
     )
     web_index = os.path.join(web_dir + "/index.html")
     web_style = os.path.join(web_dir + "/style.css")
@@ -202,27 +192,27 @@ def make_support_files(board_file, kicad_project_path, prjct_path, svg_dir1, svg
     # Generate blank images if there are layer changes between versions
 
     source_dir1 = os.path.join(
-        prjct_path, settings.output_dir, kicad_project_path, svg_dir1
+        settings.output_dir, output_dir1
     )
     source_dir2 = os.path.join(
-        prjct_path, settings.output_dir, kicad_project_path, svg_dir2
+        settings.output_dir, output_dir2
     )
 
-    project_name, _ = os.path.splitext(board_file)
+    project_name, _ = os.path.splitext(board_filename)
     svg_files1 = sorted(fnmatch.filter(os.listdir(source_dir1), project_name + '-[0-9][0-9]-*.svg'))
     svg_files2 = sorted(fnmatch.filter(os.listdir(source_dir2), project_name + '-[0-9][0-9]-*.svg'))
     layers = dict()
 
     for i, f in enumerate(svg_files1):
         file_name, _ = os.path.splitext(os.fsdecode(f))
-        project_name, _ = os.path.splitext(board_file)
+        project_name, _ = os.path.splitext(board_filename)
         layer_id = int(file_name.replace(project_name + "-", "")[0:2])
         layer_name = file_name.replace(project_name + "-", "")[3:]
         layers[layer_id] = (file_name, None)
 
     for i, f in enumerate(svg_files2):
         file_name, _ = os.path.splitext(os.fsdecode(f))
-        project_name, _ = os.path.splitext(board_file)
+        project_name, _ = os.path.splitext(board_filename)
         layer_id = int(file_name.replace(project_name + "-", "")[0:2])
         layer_name = file_name.replace(project_name + "-", "")[3:]
         if layers[layer_id]:
@@ -360,28 +350,26 @@ def html_class_from_layer_id(layer_id):
     return class_name
 
 
-def assemble_html(
-    diff_dir1, diff_dir2, board_file, kicad_project_path, prjct_path, times
-):
+def assemble_html(repo_path, kicad_project_dir, board_filename, output_dir1, output_dir2, commit_datetimes):
     """Write out HTML using template. Iterate through files in diff directories, generating
     thumbnails and three way view (triptych) page.
     """
 
     web_dir = os.path.join(
-        prjct_path, settings.output_dir, kicad_project_path, settings.web_dir
+        settings.output_dir, settings.web_dir
     )
     web_index = os.path.join(web_dir, "index.html")
 
     board1 = os.path.join(
-        prjct_path, settings.output_dir, kicad_project_path, diff_dir1, board_file
+        settings.output_dir, output_dir1, board_filename
     )
     board2 = os.path.join(
-        prjct_path, settings.output_dir, kicad_project_path, diff_dir2, board_file
+        settings.output_dir, output_dir2, board_filename
     )
 
     main_html = open(web_index, "w")
 
-    date1, time1, date2, time2 = times.replace('"', "").split(" ")
+    date1, time1, date2, time2 = commit_datetimes.replace('"', "").split(" ")
 
     board1_info = getBoardData(board1)
     board2_info = getBoardData(board2)
@@ -414,8 +402,8 @@ def assemble_html(
         date2=date2,
         time1=time1,
         time2=time2,
-        hash1=diff_dir1,
-        hash2=diff_dir2,
+        hash1=output_dir1,
+        hash2=output_dir2,
         thickness1=thickness1,
         thickness2=thickness2,
         drawings1=drawings1,
@@ -433,34 +421,34 @@ def assemble_html(
     main_html.write(index)
 
     source_dir = os.path.join(
-        prjct_path, settings.output_dir, kicad_project_path, diff_dir1
+        settings.output_dir, output_dir1
     )
     triptych_dir = os.path.join(
-        prjct_path, settings.output_dir, kicad_project_path, "web", "triptych"
+        settings.output_dir, "web", "triptych"
     )
 
     if not os.path.exists(triptych_dir):
         os.makedirs(triptych_dir)
 
     diff1 = os.path.join(
-        prjct_path, settings.output_dir, kicad_project_path, diff_dir1, board_file
+        settings.output_dir, output_dir1, board_filename
     )
     diff2 = os.path.join(
-        prjct_path, settings.output_dir, kicad_project_path, diff_dir2, board_file
+        settings.output_dir, output_dir2, board_filename
     )
     output_file = os.path.join(
-        prjct_path, settings.output_dir, kicad_project_path, "diff.txt"
+        settings.output_dir, "diff.txt"
     )
 
-    stdout, stderr = settings.run_cmd(prjct_path, [settings.diffProg, diff2, diff1])
+    stdout, stderr = settings.run_cmd(repo_path, [settings.diffProg, diff2, diff1])
 
     with open(output_file, "a") as fout:
         fout.write(stdout)
 
     diff_cmd2 = [settings.diffProg, "--suppress-common-lines", diff2, diff1]
-    stdout, stderr = settings.run_cmd(prjct_path, diff_cmd2)
+    stdout, stderr = settings.run_cmd(repo_path, diff_cmd2)
 
-    project_name, _ = os.path.splitext(board_file)
+    project_name, _ = os.path.splitext(board_filename)
     svg_files = sorted(fnmatch.filter(os.listdir(source_dir), project_name + '-[0-9][0-9]-*.svg'))
     triptych_htmls = [svg_file.replace('.svg', '.html') for svg_file in svg_files]
 
@@ -477,8 +465,8 @@ def assemble_html(
         triptych_html_path = os.path.join(triptych_dir, triptych_html)
 
         out_html = custom_page.outfile.format(
-            hash1=diff_dir1,
-            hash2=diff_dir2,
+            hash1=output_dir1,
+            hash2=output_dir2,
             layer_name=layer_name,
             filename_svg=f,
             triptych_html=triptych_html,
@@ -496,15 +484,15 @@ def assemble_html(
                 n = i+1
 
             t_out = custom_page.triptychHTML.format(
-                hash1=diff_dir1,
-                hash2=diff_dir2,
+                hash1=output_dir1,
+                hash2=output_dir2,
                 layer_name=layer_name,
                 filename_svg=f,
                 layer_class=html_class_from_layer_id(layer_id),
                 previous_page=triptych_htmls[i-1],
                 next_page=triptych_htmls[n],
                 index=i+1,
-                homebase=kicad_project_path + "/web/",
+                homebase= "web/",
                 board_title=board_title,
             )
 
@@ -661,7 +649,7 @@ class WebServerHandler(http.server.SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(
             *args,
-            directory=os.path.realpath(os.path.join(prjct_path, settings.output_dir)),
+            directory=os.path.realpath(os.path.join(settings.output_dir)),
             **kwargs
         )
 
@@ -690,23 +678,11 @@ class Select(Toplevel):
 
 def start_web_server(port, kicad_project_path):
     with socketserver.TCPServer(("", port), WebServerHandler) as httpd:
-        url = (
-            "http://127.0.0.1:"
-            + str(port)
-            + "/"
-            + kicad_project_path
-            + "/web/index.html"
-        )
+        url = "http://127.0.0.1:{port}/web/index.html".format(port=str(port))
         print("")
-        print("Starting webserver at {}".format(url))
+        print("Starting webserver at {url}".format(url=url))
         print("(Hit Ctrl+C to exit)")
-        webbrowser.open(
-            "http://127.0.0.1:"
-            + str(port)
-            + "/"
-            + kicad_project_path
-            + "/web/index.html"
-        )
+        webbrowser.open(url)
         httpd.serve_forever()
 
 
@@ -716,8 +692,8 @@ def signal_handler(sig, frame):
 
 def parse_cli_args():
     parser = argparse.ArgumentParser(description="Kicad PCB visual diffs.")
-    parser.add_argument("-a", "--commit1", type=str, help="Commit 1")
-    parser.add_argument("-b", "--commit2", type=str, help="Commit 2")
+    parser.add_argument("-a", "--commit1-hash", type=str, help="Commit 1 hash")
+    parser.add_argument("-b", "--commit2-hash", type=str, help="Commit 2 hash")
     parser.add_argument("-g", "--gui", action="store_true", help="Use gui")
     parser.add_argument("-s", "--scm", type=str, help="Select SCM (git, svn, fossil)")
     parser.add_argument(
@@ -743,7 +719,7 @@ def parse_cli_args():
         "kicad_pcb", metavar="PCB_PATH", nargs="?", help="Kicad PCB path"
     )
     parser.add_argument(
-        "-o", "--output-folder", type=str, default="kidiff", help="Set output folder. Default 'kidiff'.")
+        "-o", "--output-dir", type=str, default="kidiff", help="Set output directory. Default is 'kidiff'.")
 
     args = parser.parse_args()
 
@@ -761,10 +737,10 @@ if __name__ == "__main__":
     args = parse_cli_args()
 
     if args.kicad_pcb is None:
-        kicad_project_path, board_file = select_project_gui(args.display)
+        kicad_project_path, board_filename = select_project_gui(args.display)
     else:
         kicad_project_path = os.path.dirname(os.path.realpath(args.kicad_pcb))
-        board_file = os.path.basename(os.path.realpath(args.kicad_pcb))
+        board_filename = os.path.basename(os.path.realpath(args.kicad_pcb))
 
         if not os.path.exists(args.kicad_pcb):
             print("Kicad file {} does not exit".format(args.kicad_pcb))
@@ -775,7 +751,7 @@ if __name__ == "__main__":
             print("The file {} seems not to be a Kicad PCB".format(args.kicad_pcb))
             exit(1)
 
-    project_scms = check_project_scms(kicad_project_path)
+    project_scms = get_project_scms(kicad_project_path)
 
     if args.scm:
         scm_name = args.scm.lower()
@@ -795,7 +771,7 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    prjct_path, kicad_project = scm.get_kicad_project_path(kicad_project_path)
+    repo_path, kicad_project_dir = scm.split_repo_path(kicad_project_path)
 
     avaialble_scms = (
         ""
@@ -803,52 +779,51 @@ if __name__ == "__main__":
         else "(available: {})".format(", ".join(map(str, project_scms)))
     )
 
-    settings.output_dir = args.output_folder
+    settings.output_dir = args.output_dir
 
     print("")
-    print("  SCM Selected:", scm_name, avaialble_scms)
-    print("  Project PATH:", prjct_path)
-    print(" Kicad Project:", kicad_project)
-    print("    Board Name:", board_file)
+    print("      SCM Selected:", scm_name, avaialble_scms)
+    print("Kicad Project Path:", kicad_project_path)
+    print("         REPO Path:", repo_path)
+    print(" Kicad Project Dir:", kicad_project_dir)
+    print("   Board File Name:", board_filename)
+    print("        Output Dir:", settings.output_dir)
 
-    artifacts = scm.get_artefacts(prjct_path, kicad_project, board_file)
+    scm_artifacts = scm.get_artefacts(repo_path, kicad_project_dir, board_filename)
 
-    if args.verbose > 1:
+    if args.verbose >= 1:
+        settings.verbose = args.verbose
         print("")
         print("Commits list")
-        for artifact in artifacts:
+        for artifact in scm_artifacts:
             if artifact != " ":
                 print(artifact)
 
-    if args.commit1 is None and args.commit2 is None:
+    if args.commit1_hash is None or args.commit2_hash is None:
 
-        d1, d2 = runGUI(artifacts, board_file, kicad_project, prjct_path, scm_name)
+        commit1, commit2 = runGUI(repo_path, kicad_project_dir, board_filename, scm_name, scm_artifacts)
 
-        if not d1 or not d2:
+        if not commit1 or not commit2:
             print("\nERROR: You must select both commits.")
             exit(1)
-    else:
-        if args.commit1 is None:
-            d1 = artifacts[0]
-        else:
-            d1 = args.commit1
 
-        if args.commit2 is None:
-            d2 = artifacts[0]
-        else:
-            d2 = args.commit2
+    if args.commit1_hash is not None:
+        commit1 = args.commit1_hash
+
+    if args.commit2_hash is not None:
+        commit2 = args.commit2_hash
 
     print("")
-    print(" Commit 1 (a):", d1)
-    print(" Commit 2 (b):", d2)
+    print("Commit 1 (a):", commit1)
+    print("Commit 2 (b):", commit2)
 
-    d1, d2, datetimes = scm.get_boards(d1, d2, board_file, kicad_project, prjct_path)
+    commit1, commit2, commit_datetimes = scm.get_boards(repo_path, kicad_project_dir, board_filename, commit1, commit2)
 
-    svg_dir1, svg_dir2, _, _ = make_svg(d1, d2, board_file, kicad_project, prjct_path)
+    output_dir1, output_dir2 = make_svg(repo_path, kicad_project_dir, board_filename, commit1, commit2)
 
-    make_support_files(board_file, kicad_project, prjct_path, svg_dir1, svg_dir2)
+    generate_assets(repo_path, kicad_project_dir, board_filename, output_dir1, output_dir2)
 
-    assemble_html(svg_dir1, svg_dir2, board_file, kicad_project, prjct_path, datetimes)
+    assemble_html(repo_path, kicad_project_dir, board_filename, output_dir1, output_dir2, commit_datetimes)
 
     if not args.webserver_disable:
-        start_web_server(args.port, kicad_project)
+        start_web_server(args.port, kicad_project_dir)

--- a/kidiff
+++ b/kidiff
@@ -736,6 +736,9 @@ if __name__ == "__main__":
     signal.signal(signal.SIGINT, signal_handler)
     args = parse_cli_args()
 
+    if args.verbose:
+        settings.verbose = args.verbose
+
     if args.kicad_pcb is None:
         kicad_project_path, board_filename = select_project_gui(args.display)
     else:
@@ -792,7 +795,6 @@ if __name__ == "__main__":
     scm_artifacts = scm.get_artefacts(repo_path, kicad_project_dir, board_filename)
 
     if args.verbose >= 1:
-        settings.verbose = args.verbose
         print("")
         print("Commits list")
         for artifact in scm_artifacts:

--- a/kidiff
+++ b/kidiff
@@ -63,14 +63,15 @@ def select_project_gui(display):
     )
 
     if selected:
-        repo_path, kicad_pcb = os.path.split(selected.name)
+        kicad_board_path = selected.name
+        repo_path, kicad_pcb = os.path.split(kicad_board_path)
     else:
         gui.destroy()
         exit()
 
     gui.destroy()
 
-    return (repo_path, kicad_pcb)
+    return (kicad_board_path, repo_path, kicad_pcb)
 
 
 def get_project_scms(repo_path):
@@ -104,7 +105,7 @@ def get_project_scms(repo_path):
     return scms
 
 
-def make_svg(repo_path, kicad_project_dir, board_filename, commit1, commit2):
+def make_svg(kicad_pcb_path, repo_path, kicad_project_dir, board_filename, commit1, commit2):
     """Hands off required .kicad_pcb files to "plotpcb"
     and generate .svg files. Routine is quick so all
     layers are plotted to svg."""
@@ -122,20 +123,16 @@ def make_svg(repo_path, kicad_project_dir, board_filename, commit1, commit2):
     commit1_output_path = os.path.join(settings.output_dir, commit1_hash)
     commit2_output_path = os.path.join(settings.output_dir, commit2_hash)
 
-    # Commit's board recovered from SCM history
-    commit1_board_path = os.path.join(commit1_output_path, board_filename)
-    commit2_board_path = os.path.join(commit2_output_path, board_filename)
-
     if not os.path.exists(commit1_output_path):
         os.makedirs(commit1_output_path)
 
     if not os.path.exists(commit2_output_path):
         os.makedirs(commit2_output_path)
 
-    plot1_cmd = [settings.plot_prog, commit1_board_path] #, "-o", commit1_output_path]
-    plot2_cmd = [settings.plot_prog, commit2_board_path] #, "-o", commit2_output_path]
+    plot1_cmd = [settings.plot_prog, board_filename]
+    plot2_cmd = [settings.plot_prog, board_filename]
 
-    stdout, stderr = settings.run_cmd(os.path.join(repo_path, kicad_project_dir), plot1_cmd)
+    stdout, stderr = settings.run_cmd(commit1_output_path, plot1_cmd)
     plot1_stdout = stdout.splitlines()
     plot1_stderr = stderr
 
@@ -144,7 +141,7 @@ def make_svg(repo_path, kicad_project_dir, board_filename, commit1, commit2):
         print("Plot1 error: " + plot1_stderr)
         exit(1)
 
-    stdout, stderr = settings.run_cmd(os.path.join(repo_path, kicad_project_dir), plot2_cmd)
+    stdout, stderr = settings.run_cmd(commit2_output_path, plot2_cmd)
     plot2_stdout = stdout.splitlines()
     plot2_stderr = stderr
 
@@ -168,9 +165,8 @@ def generate_assets(repo_path, kicad_project_dir, board_filename, output_dir1, o
     Setup web directories for output
     """
 
-    web_dir = os.path.join(
-        settings.output_dir, settings.web_dir
-    )
+    web_dir = os.path.join(settings.output_dir, settings.web_dir)
+
     web_index = os.path.join(web_dir + "/index.html")
     web_style = os.path.join(web_dir + "/style.css")
     web_favicon = os.path.join(web_dir + "/favicon.ico")
@@ -189,14 +185,8 @@ def generate_assets(repo_path, kicad_project_dir, board_filename, output_dir1, o
     if os.path.exists(web_index):
         os.remove(web_index)
 
-    # Generate blank images if there are layer changes between versions
-
-    source_dir1 = os.path.join(
-        settings.output_dir, output_dir1
-    )
-    source_dir2 = os.path.join(
-        settings.output_dir, output_dir2
-    )
+    source_dir1 = os.path.join(settings.output_dir, output_dir1)
+    source_dir2 = os.path.join(settings.output_dir, output_dir2)
 
     project_name, _ = os.path.splitext(board_filename)
     svg_files1 = sorted(fnmatch.filter(os.listdir(source_dir1), project_name + '-[0-9][0-9]-*.svg'))
@@ -350,29 +340,23 @@ def html_class_from_layer_id(layer_id):
     return class_name
 
 
-def assemble_html(repo_path, kicad_project_dir, board_filename, output_dir1, output_dir2, commit_datetimes):
+def assemble_html(kicad_pcb_path, repo_path, kicad_project_dir, board_filename, output_dir1, output_dir2, commit_datetimes):
     """Write out HTML using template. Iterate through files in diff directories, generating
     thumbnails and three way view (triptych) page.
     """
 
-    web_dir = os.path.join(
-        settings.output_dir, settings.web_dir
-    )
+    web_dir = os.path.join(settings.output_dir, settings.web_dir)
     web_index = os.path.join(web_dir, "index.html")
 
-    board1 = os.path.join(
-        settings.output_dir, output_dir1, board_filename
-    )
-    board2 = os.path.join(
-        settings.output_dir, output_dir2, board_filename
-    )
+    board1_path = os.path.join(settings.output_dir, output_dir1, board_filename)
+    board2_path = os.path.join(settings.output_dir, output_dir2, board_filename)
 
     main_html = open(web_index, "w")
 
     date1, time1, date2, time2 = commit_datetimes.replace('"', "").split(" ")
 
-    board1_info = getBoardData(board1)
-    board2_info = getBoardData(board2)
+    board1_info = getBoardData(board1_path)
+    board2_info = getBoardData(board2_path)
 
     board_title = board1_info.get("title")
     board_company = board1_info.get("company")
@@ -420,33 +404,20 @@ def assemble_html(repo_path, kicad_project_dir, board_filename, output_dir1, out
 
     main_html.write(index)
 
-    source_dir = os.path.join(
-        settings.output_dir, output_dir1
-    )
-    triptych_dir = os.path.join(
-        settings.output_dir, "web", "triptych"
-    )
+    source_dir = os.path.join(settings.output_dir, output_dir1)
+    triptych_dir = os.path.join(settings.output_dir, "web", "triptych")
 
     if not os.path.exists(triptych_dir):
         os.makedirs(triptych_dir)
 
-    diff1 = os.path.join(
-        settings.output_dir, output_dir1, board_filename
-    )
-    diff2 = os.path.join(
-        settings.output_dir, output_dir2, board_filename
-    )
-    output_file = os.path.join(
-        settings.output_dir, "diff.txt"
-    )
+    board1_path = os.path.join(output_dir1, board_filename)
+    board2_path = os.path.join(output_dir2, board_filename)
+    diff_path   = os.path.join(settings.output_dir, "diff.txt")
 
-    stdout, stderr = settings.run_cmd(repo_path, [settings.diffProg, diff2, diff1])
+    stdout, stderr = settings.run_cmd(settings.output_dir, [settings.diffProg, board2_path, board1_path])
 
-    with open(output_file, "a") as fout:
+    with open(diff_path, "a") as fout:
         fout.write(stdout)
-
-    diff_cmd2 = [settings.diffProg, "--suppress-common-lines", diff2, diff1]
-    stdout, stderr = settings.run_cmd(repo_path, diff_cmd2)
 
     project_name, _ = os.path.splitext(board_filename)
     svg_files = sorted(fnmatch.filter(os.listdir(source_dir), project_name + '-[0-9][0-9]-*.svg'))
@@ -457,9 +428,7 @@ def assemble_html(repo_path, kicad_project_dir, board_filename, output_dir1, out
         file_name, _ = os.path.splitext(os.fsdecode(f))
         layer_id = int(file_name.replace(project_name + "-", "")[0:2])
         layer_name = file_name.replace(project_name + "-", "")[3:]
-        layer_name_orig = layer_name.replace(
-            "_", "."
-        )  # not sure this is good and works all the time
+        layer_name_orig = layer_name.replace("_", ".")  # not sure this is good and works all the time
 
         triptych_html = file_name + ".html"
         triptych_html_path = os.path.join(triptych_dir, triptych_html)
@@ -740,9 +709,10 @@ if __name__ == "__main__":
         settings.verbose = args.verbose
 
     if args.kicad_pcb is None:
-        kicad_project_path, board_filename = select_project_gui(args.display)
+        kicad_pcb_path, kicad_project_path, board_filename = select_project_gui(args.display)
     else:
-        kicad_project_path = os.path.dirname(os.path.realpath(args.kicad_pcb))
+        kicad_pcb_path = os.path.realpath(args.kicad_pcb)
+        kicad_project_path = os.path.dirname(kicad_pcb_path)
         board_filename = os.path.basename(os.path.realpath(args.kicad_pcb))
 
         if not os.path.exists(args.kicad_pcb):
@@ -782,10 +752,11 @@ if __name__ == "__main__":
         else "(available: {})".format(", ".join(map(str, project_scms)))
     )
 
-    settings.output_dir = args.output_dir
+    settings.output_dir = os.path.realpath(args.output_dir)
 
     print("")
     print("      SCM Selected:", scm_name, avaialble_scms)
+    print("  Kicad Board Path:", kicad_pcb_path)
     print("Kicad Project Path:", kicad_project_path)
     print("         REPO Path:", repo_path)
     print(" Kicad Project Dir:", kicad_project_dir)
@@ -819,13 +790,13 @@ if __name__ == "__main__":
     print("Commit 1 (a):", commit1)
     print("Commit 2 (b):", commit2)
 
-    commit1, commit2, commit_datetimes = scm.get_boards(repo_path, kicad_project_dir, board_filename, commit1, commit2)
+    commit1, commit2, commit_datetimes = scm.get_boards(kicad_pcb_path, repo_path, kicad_project_dir, board_filename, commit1, commit2)
 
-    output_dir1, output_dir2 = make_svg(repo_path, kicad_project_dir, board_filename, commit1, commit2)
+    output_dir1, output_dir2 = make_svg(kicad_pcb_path, repo_path, kicad_project_dir, board_filename, commit1, commit2)
 
     generate_assets(repo_path, kicad_project_dir, board_filename, output_dir1, output_dir2)
 
-    assemble_html(repo_path, kicad_project_dir, board_filename, output_dir1, output_dir2, commit_datetimes)
+    assemble_html(kicad_pcb_path, repo_path, kicad_project_dir, board_filename, output_dir1, output_dir2, commit_datetimes)
 
     if not args.webserver_disable:
         start_web_server(args.port, kicad_project_dir)

--- a/kidiff
+++ b/kidiff
@@ -117,14 +117,14 @@ def make_svg(d1, d2, board_file, kicad_project_path, prjct_path):
     else:
         d1 = "local"
 
-    d1_svg = os.path.join(prjct_path, settings.plot_dir, kicad_project_path, d1)
+    d1_svg = os.path.join(prjct_path, settings.output_dir, kicad_project_path, d1)
 
     if not d2 == board_file:
         d2 = d2[:7]
     else:
         d2 = "local"
 
-    d2_svg = os.path.join(prjct_path, settings.plot_dir, kicad_project_path, d2)
+    d2_svg = os.path.join(prjct_path, settings.output_dir, kicad_project_path, d2)
 
     diff1 = os.path.join(d1_svg, board_file)
     diff2 = os.path.join(d2_svg, board_file)
@@ -179,7 +179,7 @@ def make_support_files(board_file, kicad_project_path, prjct_path, svg_dir1, svg
     """
 
     web_dir = os.path.join(
-        prjct_path, settings.plot_dir, kicad_project_path, settings.web_dir
+        prjct_path, settings.output_dir, kicad_project_path, settings.web_dir
     )
     web_index = os.path.join(web_dir + "/index.html")
     web_style = os.path.join(web_dir + "/style.css")
@@ -202,10 +202,10 @@ def make_support_files(board_file, kicad_project_path, prjct_path, svg_dir1, svg
     # Generate blank images if there are layer changes between versions
 
     source_dir1 = os.path.join(
-        prjct_path, settings.plot_dir, kicad_project_path, svg_dir1
+        prjct_path, settings.output_dir, kicad_project_path, svg_dir1
     )
     source_dir2 = os.path.join(
-        prjct_path, settings.plot_dir, kicad_project_path, svg_dir2
+        prjct_path, settings.output_dir, kicad_project_path, svg_dir2
     )
 
     project_name, _ = os.path.splitext(board_file)
@@ -368,15 +368,15 @@ def assemble_html(
     """
 
     web_dir = os.path.join(
-        prjct_path, settings.plot_dir, kicad_project_path, settings.web_dir
+        prjct_path, settings.output_dir, kicad_project_path, settings.web_dir
     )
     web_index = os.path.join(web_dir, "index.html")
 
     board1 = os.path.join(
-        prjct_path, settings.plot_dir, kicad_project_path, diff_dir1, board_file
+        prjct_path, settings.output_dir, kicad_project_path, diff_dir1, board_file
     )
     board2 = os.path.join(
-        prjct_path, settings.plot_dir, kicad_project_path, diff_dir2, board_file
+        prjct_path, settings.output_dir, kicad_project_path, diff_dir2, board_file
     )
 
     main_html = open(web_index, "w")
@@ -433,23 +433,23 @@ def assemble_html(
     main_html.write(index)
 
     source_dir = os.path.join(
-        prjct_path, settings.plot_dir, kicad_project_path, diff_dir1
+        prjct_path, settings.output_dir, kicad_project_path, diff_dir1
     )
     triptych_dir = os.path.join(
-        prjct_path, settings.plot_dir, kicad_project_path, "web", "triptych"
+        prjct_path, settings.output_dir, kicad_project_path, "web", "triptych"
     )
 
     if not os.path.exists(triptych_dir):
         os.makedirs(triptych_dir)
 
     diff1 = os.path.join(
-        prjct_path, settings.plot_dir, kicad_project_path, diff_dir1, board_file
+        prjct_path, settings.output_dir, kicad_project_path, diff_dir1, board_file
     )
     diff2 = os.path.join(
-        prjct_path, settings.plot_dir, kicad_project_path, diff_dir2, board_file
+        prjct_path, settings.output_dir, kicad_project_path, diff_dir2, board_file
     )
     output_file = os.path.join(
-        prjct_path, settings.plot_dir, kicad_project_path, "diff.txt"
+        prjct_path, settings.output_dir, kicad_project_path, "diff.txt"
     )
 
     stdout, stderr = settings.run_cmd(prjct_path, [settings.diffProg, diff2, diff1])
@@ -661,7 +661,7 @@ class WebServerHandler(http.server.SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(
             *args,
-            directory=os.path.realpath(os.path.join(prjct_path, settings.plot_dir)),
+            directory=os.path.realpath(os.path.join(prjct_path, settings.output_dir)),
             **kwargs
         )
 
@@ -742,6 +742,8 @@ def parse_cli_args():
     parser.add_argument(
         "kicad_pcb", metavar="PCB_PATH", nargs="?", help="Kicad PCB path"
     )
+    parser.add_argument(
+        "-o", "--output-folder", type=str, default="kidiff", help="Set output folder. Default 'kidiff'.")
 
     args = parser.parse_args()
 
@@ -800,6 +802,9 @@ if __name__ == "__main__":
         if len(project_scms) <= 1
         else "(available: {})".format(", ".join(map(str, project_scms)))
     )
+
+    settings.output_dir = args.output_folder
+
     print("")
     print("  SCM Selected:", scm_name, avaialble_scms)
     print("  Project PATH:", prjct_path)

--- a/plotPCB.py
+++ b/plotPCB.py
@@ -13,9 +13,8 @@ import shutil
 import platform
 
 if platform.system() == "Darwin":
-    sys.path.insert(
-        0, "/Applications/Kicad/kicad.app/Contents/Frameworks/python/site-packages/"
-    )
+    sys.path.insert(0, "/Applications/Kicad/kicad.app/Contents/Frameworks/python/site-packages/")
+    sys.path.insert(0, "/Applications/KiCad/kicad.app/Contents/Frameworks/python/site-packages/")
 
 import pcbnew as pn
 

--- a/plotPCB.py
+++ b/plotPCB.py
@@ -38,7 +38,7 @@ def processBoard(board_path, plot_dir, quiet=0, verbose=0):
     board_version = board.GetFileFormatVersionAtLoad()
     print("\nBoard version: {}".format(board_version))
 
-    board_name, _ = os.path.splitext(board_path)
+    board_name = os.path.basename(board_path)
 
     boardbox = board.ComputeBoundingBox()
     boardxl = boardbox.GetX()
@@ -99,15 +99,14 @@ def processBoard(board_path, plot_dir, quiet=0, verbose=0):
 
         layer_name = board.GetLayerName(layer_id).replace(".", "_")
         plot_sufix = str(layer_id).zfill(2) + "-" + layer_name
-        layer_filename = os.path.join(plot_dir, board_name + "-" + plot_sufix + ".svg")
+        layer_filename = os.path.join(board_path + "-" + plot_sufix + ".svg")
 
         pctl.OpenPlotfile(plot_sufix, pn.PLOT_FORMAT_SVG, layer_name)
         pctl.PlotLayer()
 
         if not quiet:
-            print(
-                "{:2d} {:2d} {} {}".format(
-                    i + 1, layer_id, layer_name.ljust(len(max_string_len)), layer_filename
+            print("{:2d} {:2d} {} {}".format(
+                i + 1, layer_id, layer_name.ljust(len(max_string_len)), layer_filename
                 )
             )
 
@@ -160,6 +159,16 @@ if __name__ == "__main__":
 
     if args.output_folder:
         plot_dir = args.output_folder
+        if not os.path.exists(plot_dir):
+            try:
+                os.mkdir(plot_dir)
+            except:
+                print("Could not create", plot_dir)
+                exit(1)
+
+
+    print("board_path:", board_path)
+    print("plot_dir:", plot_dir)
 
     if args.verbose:
         print()
@@ -168,10 +177,5 @@ if __name__ == "__main__":
         print("Minor version:", version_minor)
         print("Patch version:", version_patch)
         print("Extra version:", extra_version_str)
-
-    # if not args.quiet:
-    #     print("\nBoard made with PCBNew {}.{}.{}{}".format(
-    #         version_major, version_minor, version_patch, extra_version_str)
-    #     )
 
     processBoard(board_path, plot_dir, args.quiet, args.verbose)

--- a/plotpcb
+++ b/plotpcb
@@ -34,7 +34,12 @@ case ${OSTYPE} in
 	darwin*)
 		SCRIPT=$(readlink_osx "$0")
 		SCRIPTPATH=$(dirname "${SCRIPT}")
-		/Applications/Kicad/kicad.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python "${SCRIPTPATH}/plotPCB.py" "$@"
+
+		kicad_app_path=/Applications/Kicad/kicad.app/
+		if [[ ! -d ${kicad_app_path} ]]; then
+			kicad_app_path=/Applications/KiCad/kicad.app/
+		fi
+		${kicad_app_path}/Contents/Frameworks/Python.framework/Versions/Current/bin/python "${SCRIPTPATH}/plotPCB.py" "$@"
 		;;
 
 	# Linux

--- a/scms/fossil.py
+++ b/scms/fossil.py
@@ -8,114 +8,91 @@ from scms.generic import scm as generic_scm
 
 
 class scm(generic_scm):
+
     @staticmethod
-    def get_boards(diff1, diff2, prjct_name, kicad_project_path, prjct_path):
+    def get_boards(repo_path, kicad_project_dir, board_filename, commit1, commit2):
         """Given two Fossil artifacts, write out two kicad_pcb files to their respective
         directories (named after the artifacts). Returns the date and time of both commits"""
 
-        if not diff1 == prjct_name:
-            artifact1 = diff1[:6]
+        if not commit1 == board_filename:
+            artifact1 = commit1[:6]
         else:
             artifact1 = "local"
 
-        if not diff2 == prjct_name:
-            artifact2 = diff2[:6]
+        if not commit2 == board_filename:
+            artifact2 = commit2[:6]
         else:
             artifact2 = "local"
 
         # Using this to fix the path when there is no subproject
-        prj_path = kicad_project_path + "/"
-        if kicad_project_path == ".":
+        prj_path = kicad_project_dir + "/"
+        if kicad_project_dir == ".":
             prj_path = ""
 
-        if (not diff1 == prjct_name) and (not diff2 == prjct_name):
+        if (not commit1 == board_filename) and (not commit2 == board_filename):
 
             cmd = ["fossil", "diff", "--brief", "-r", artifact1, "--to", artifact2]
 
-            print("")
-            print("Getting Boards")
-            print(' '.join(cmd))
-
-            stdout, stderr = settings.run_cmd(prjct_path, cmd)
+            stdout, stderr = settings.run_cmd(repo_path, cmd)
             changed = ".kicad_pcb" in stdout
 
             if not changed:
                 print("\nThere is no difference in .kicad_pcb file in selected commits")
 
         outputDir1 = os.path.join(
-            prjct_path, settings.output_dir, kicad_project_path, artifact1
+            settings.output_dir, artifact1
         )
         if not os.path.exists(outputDir1):
             os.makedirs(outputDir1)
 
         outputDir2 = os.path.join(
-            prjct_path, settings.output_dir, kicad_project_path, artifact2
+            settings.output_dir, artifact2
         )
         if not os.path.exists(outputDir2):
             os.makedirs(outputDir2)
 
-        print("")
-        print("Setting output paths")
-        print(outputDir1)
-        print(outputDir2)
+        fossilPath = os.path.join(prj_path, board_filename)
 
-        fossilPath = os.path.join(prj_path, prjct_name)
-
-        print("")
-        print("Setting artifacts paths")
-        print("fossilPath   :", fossilPath)
-
-        if not diff1 == prjct_name:
+        if not commit1 == board_filename:
             fossilArtifact1 = [
                 "fossil",
                 "cat",
-                prjct_path + fossilPath,
+                repo_path + fossilPath,
                 "-r",
                 artifact1,
             ]
-            print("Fossil artifact1: ", ' '.join(fossilArtifact1))
-        else:
-            print("Fossil artifact1: ", diff1)
 
-        if not diff2 == prjct_name:
+        if not commit2 == board_filename:
             fossilArtifact2 = [
                 "fossil",
                 "cat",
-                prjct_path + fossilPath,
+                repo_path + fossilPath,
                 "-r",
                 artifact2,
             ]
-            print("Fossil artifact2: ", ' '.join(fossilArtifact2))
-        else:
-            print("Fossil artifact2: ", diff2)
 
-        print("")
-        print("Checking datetime")
-
-        if not diff1 == prjct_name:
+        if not commit1 == board_filename:
             fossilDateTime1 = ["fossil", "info", artifact1]
-            print(' '.join(fossilDateTime1))
 
         else:
-            artifact1 = prjct_name
-            modTimesinceEpoc = os.path.getmtime(prjct_name)
+            artifact1 = board_filename
+            modTimesinceEpoc = os.path.getmtime(board_filename)
             dateDiff1 = time.strftime("%Y-%m-%d", time.localtime(modTimesinceEpoc))
             timeDiff1 = time.strftime("%H:%M:%S", time.localtime(modTimesinceEpoc))
 
-        if not diff2 == prjct_name:
+        if not commit2 == board_filename:
             fossilDateTime2 = ["fossil", "info", artifact2]
-            print(' '.join(fossilDateTime2))
         else:
-            artifact2 = prjct_name
-            modTimesinceEpoc = os.path.getmtime(prjct_name)
+            artifact2 = board_filename
+            modTimesinceEpoc = os.path.getmtime(board_filename)
             dateDiff2 = time.strftime("%Y-%m-%d", time.localtime(modTimesinceEpoc))
             timeDiff2 = time.strftime("%H:%M:%S", time.localtime(modTimesinceEpoc))
 
-        if not diff1 == prjct_name:
-            stdout, stderr = settings.run_cmd(prjct_path, fossilArtifact1)
-            with open(os.path.join(outputDir1, prjct_name), "w") as f:
+        if not commit1 == board_filename:
+            stdout, stderr = settings.run_cmd(repo_path, fossilArtifact1)
+            with open(os.path.join(outputDir1, board_filename), "w") as f:
                 f.write(stdout)
-            dateTime, _ = settings.run_cmd(prjct_path, fossilDateTime1)
+            dateTime, _ = settings.run_cmd(repo_path, fossilDateTime1)
             (
                 uuid,
                 _,
@@ -132,13 +109,13 @@ class scm(generic_scm):
                 *junk1,
             ) = dateTime.split(" ")
         else:
-            shutil.copyfile(prjct_name, os.path.join(outputDir1, prjct_name))
+            shutil.copyfile(board_filename, os.path.join(outputDir1, board_filename))
 
-        if not diff2 == prjct_name:
-            stdout, stderr = settings.run_cmd(prjct_path, fossilArtifact2)
-            with open(os.path.join(outputDir2, prjct_name), "w") as f:
+        if not commit2 == board_filename:
+            stdout, stderr = settings.run_cmd(repo_path, fossilArtifact2)
+            with open(os.path.join(outputDir2, board_filename), "w") as f:
                 f.write(stdout)
-            dateTime, _ = settings.run_cmd(prjct_path, fossilDateTime2)
+            dateTime, _ = settings.run_cmd(repo_path, fossilDateTime2)
             (
                 uuid,
                 _,
@@ -155,38 +132,34 @@ class scm(generic_scm):
                 *junk2,
             ) = dateTime.split(" ")
         else:
-            shutil.copyfile(prjct_name, os.path.join(outputDir2, prjct_name))
+            shutil.copyfile(board_filename, os.path.join(outputDir2, board_filename))
 
         dateTime = dateDiff1 + " " + timeDiff1 + " " + dateDiff2 + " " + timeDiff2
 
         return artifact1, artifact2, dateTime
 
     @staticmethod
-    def get_artefacts(prjct_path, kicad_project_path, board_file):
+    def get_artefacts(repo_path, kicad_project_dir, board_filename):
         """Returns list of artifacts from a directory"""
 
-        cmd = ["fossil", "finfo", "-b", os.path.join(kicad_project_path, board_file)]
+        cmd = ["fossil", "finfo", "-b", os.path.join(kicad_project_dir, board_filename)]
 
-        print("")
-        print("Getting artifacts")
-        print(cmd)
-
-        stdout, stderr = settings.run_cmd(prjct_path, cmd)
-        artifacts = [board_file] + [
+        stdout, stderr = settings.run_cmd(repo_path, cmd)
+        artifacts = [board_filename] + [
             a.replace(" ", " | ", 4) for a in stdout.splitlines()
         ]
 
         return artifacts
 
     @staticmethod
-    def get_kicad_project_path(prjct_path):
+    def split_repo_path(kicad_project_path):
         """Returns the root folder of the repository"""
 
         cmd = ["fossil", "status"]
 
-        stdout, _ = settings.run_cmd(prjct_path, cmd)
-        repo_root_path = stdout.split()[3]
+        stdout, _ = settings.run_cmd(kicad_project_path, cmd)
+        repo_path = stdout.split()[3]
 
-        kicad_project_path = os.path.relpath(prjct_path, repo_root_path)
+        kicad_project_dir = os.path.relpath(kicad_project_path, repo_path)
 
-        return repo_root_path, kicad_project_path
+        return repo_path, kicad_project_dir

--- a/scms/fossil.py
+++ b/scms/fossil.py
@@ -10,7 +10,7 @@ from scms.generic import scm as generic_scm
 class scm(generic_scm):
 
     @staticmethod
-    def get_boards(repo_path, kicad_project_dir, board_filename, commit1, commit2):
+    def get_boards(kicad_pcb_path, repo_path, kicad_project_dir, board_filename, commit1, commit2):
         """Given two Fossil artifacts, write out two kicad_pcb files to their respective
         directories (named after the artifacts). Returns the date and time of both commits"""
 
@@ -76,7 +76,7 @@ class scm(generic_scm):
 
         else:
             artifact1 = board_filename
-            modTimesinceEpoc = os.path.getmtime(board_filename)
+            modTimesinceEpoc = os.path.getmtime(kicad_pcb_path)
             dateDiff1 = time.strftime("%Y-%m-%d", time.localtime(modTimesinceEpoc))
             timeDiff1 = time.strftime("%H:%M:%S", time.localtime(modTimesinceEpoc))
 
@@ -84,7 +84,7 @@ class scm(generic_scm):
             fossilDateTime2 = ["fossil", "info", artifact2]
         else:
             artifact2 = board_filename
-            modTimesinceEpoc = os.path.getmtime(board_filename)
+            modTimesinceEpoc = os.path.getmtime(kicad_pcb_path)
             dateDiff2 = time.strftime("%Y-%m-%d", time.localtime(modTimesinceEpoc))
             timeDiff2 = time.strftime("%H:%M:%S", time.localtime(modTimesinceEpoc))
 
@@ -109,7 +109,7 @@ class scm(generic_scm):
                 *junk1,
             ) = dateTime.split(" ")
         else:
-            shutil.copyfile(board_filename, os.path.join(outputDir1, board_filename))
+            shutil.copyfile(kicad_pcb_path, os.path.join(outputDir1, board_filename))
 
         if not commit2 == board_filename:
             stdout, stderr = settings.run_cmd(repo_path, fossilArtifact2)
@@ -132,7 +132,7 @@ class scm(generic_scm):
                 *junk2,
             ) = dateTime.split(" ")
         else:
-            shutil.copyfile(board_filename, os.path.join(outputDir2, board_filename))
+            shutil.copyfile(kicad_pcb_path, os.path.join(outputDir2, board_filename))
 
         dateTime = dateDiff1 + " " + timeDiff1 + " " + dateDiff2 + " " + timeDiff2
 

--- a/scms/fossil.py
+++ b/scms/fossil.py
@@ -43,13 +43,13 @@ class scm(generic_scm):
                 print("\nThere is no difference in .kicad_pcb file in selected commits")
 
         outputDir1 = os.path.join(
-            prjct_path, settings.plot_dir, kicad_project_path, artifact1
+            prjct_path, settings.output_dir, kicad_project_path, artifact1
         )
         if not os.path.exists(outputDir1):
             os.makedirs(outputDir1)
 
         outputDir2 = os.path.join(
-            prjct_path, settings.plot_dir, kicad_project_path, artifact2
+            prjct_path, settings.output_dir, kicad_project_path, artifact2
         )
         if not os.path.exists(outputDir2):
             os.makedirs(outputDir2)

--- a/scms/generic.py
+++ b/scms/generic.py
@@ -6,7 +6,7 @@ import settings
 class scm:
 
     @staticmethod
-    def get_boards(repo_path, kicad_project_dir, board_filename, commit1, commit2):
+    def get_boards(kicad_pcb_path, repo_path, kicad_project_dir, board_filename, commit1, commit2):
         pass
 
     @staticmethod

--- a/scms/generic.py
+++ b/scms/generic.py
@@ -4,18 +4,15 @@ import settings
 
 
 class scm:
+
     @staticmethod
-    def get_board_path(prjct_name, prjct_path):
+    def get_boards(repo_path, kicad_project_dir, board_filename, commit1, commit2):
         pass
 
     @staticmethod
-    def get_boards(diff1, diff2, prjct_name, kicad_project_path, prjct_path):
+    def get_artefacts(repo_path, board_filename):
         pass
 
     @staticmethod
-    def get_artefacts(prjct_path, board_file):
-        pass
-
-    @staticmethod
-    def get_kicad_project_path(prjct_path):
+    def split_repo_path(kicad_project_path):
         pass

--- a/scms/git.py
+++ b/scms/git.py
@@ -41,13 +41,13 @@ class scm(generic_scm):
                 print("\nThere is no difference in .kicad_pcb file in selected commits")
 
         outputDir1 = os.path.join(
-            prjct_path, settings.plot_dir, kicad_project_path, artifact1
+            prjct_path, settings.output_dir, kicad_project_path, artifact1
         )
         if not os.path.exists(outputDir1):
             os.makedirs(outputDir1)
 
         outputDir2 = os.path.join(
-            prjct_path, settings.plot_dir, kicad_project_path, artifact2
+            prjct_path, settings.output_dir, kicad_project_path, artifact2
         )
         if not os.path.exists(outputDir2):
             os.makedirs(outputDir2)

--- a/scms/git.py
+++ b/scms/git.py
@@ -7,118 +7,100 @@ from scms.generic import scm as generic_scm
 
 
 class scm(generic_scm):
+
     @staticmethod
-    def get_boards(diff1, diff2, prjct_name, kicad_project_path, prjct_path):
+    def get_boards(repo_path, kicad_project_dir, board_filename, commit1, commit2):
         """Given two git artifacts, write out two kicad_pcb files to their respective
         directories (named after the artifact). Returns the date and time of both commits"""
 
-        if not diff1 == prjct_name:
-            artifact1 = diff1[:7]
+        if not commit1 == board_filename:
+            artifact1 = commit1[:7]
         else:
             artifact1 = "local"
 
-        if not diff2 == prjct_name:
-            artifact2 = diff2[:7]
+        if not commit2 == board_filename:
+            artifact2 = commit2[:7]
         else:
             artifact2 = "local"
 
         # Using this to fix the path when there is no subproject
-        prj_path = kicad_project_path + "/"
-        if kicad_project_path == ".":
+        prj_path = kicad_project_dir + "/"
+        if kicad_project_dir == ".":
             prj_path = ""
 
-        if (not diff1 == prjct_name) and (not diff2 == prjct_name):
+        if (not commit1 == board_filename) and (not commit2 == board_filename):
             cmd = ["git", "diff", "--name-only", artifact1, artifact2, "."]
 
-            print("")
-            print("Getting boards")
-            print(' '.join(cmd))
-
-            stdout, stderr = settings.run_cmd(prjct_path, cmd)
-            changed = (prj_path + prjct_name) in stdout
+            stdout, stderr = settings.run_cmd(repo_path, cmd)
+            changed = (prj_path + board_filename) in stdout
 
             if not changed:
                 print("\nThere is no difference in .kicad_pcb file in selected commits")
 
         outputDir1 = os.path.join(
-            prjct_path, settings.output_dir, kicad_project_path, artifact1
+            settings.output_dir, artifact1
         )
         if not os.path.exists(outputDir1):
             os.makedirs(outputDir1)
 
         outputDir2 = os.path.join(
-            prjct_path, settings.output_dir, kicad_project_path, artifact2
+            settings.output_dir, artifact2
         )
         if not os.path.exists(outputDir2):
             os.makedirs(outputDir2)
 
-        gitPath = os.path.join(prj_path, prjct_name)
+        board_subpath = os.path.join(prj_path, board_filename)
 
-        print("")
-        print("Setting artifacts paths")
-        print("gitPath      :", gitPath)
+        if not commit1 == board_filename:
+            gitArtifact1 = ["git", "show", artifact1 + ":" + board_subpath]
 
-        if not diff1 == prjct_name:
-            gitArtifact1 = ["git", "show", artifact1 + ":" + gitPath]
-            print("Git artifact1: ", ' '.join(gitArtifact1))
-        else:
-            print("Git artifact1: ", diff1)
+        if not commit2 == board_filename:
+            gitArtifact2 = ["git", "show", artifact2 + ":" + board_subpath]
 
-        if not diff2 == prjct_name:
-            gitArtifact2 = ["git", "show", artifact2 + ":" + gitPath]
-            print("Git artifact2: ", ' '.join(gitArtifact2))
-        else:
-            print("Git artifact2: ", diff2)
-
-        if not diff1 == prjct_name:
-            stdout, stderr = settings.run_cmd(prjct_path, gitArtifact1)
-            with open(os.path.join(outputDir1, prjct_name), "w") as fout1:
+        if not commit1 == board_filename:
+            stdout, stderr = settings.run_cmd(repo_path, gitArtifact1)
+            with open(os.path.join(outputDir1, board_filename), "w") as fout1:
                 fout1.write(stdout)
         else:
-            shutil.copyfile(prjct_name, os.path.join(outputDir1, prjct_name))
+            shutil.copyfile(board_filename, os.path.join(outputDir1, board_filename))
 
-        if not diff2 == prjct_name:
-            stdout, stderr = settings.run_cmd(prjct_path, gitArtifact2)
-            with open(os.path.join(outputDir2, prjct_name), "w") as fout2:
+        if not commit2 == board_filename:
+            stdout, stderr = settings.run_cmd(repo_path, gitArtifact2)
+            with open(os.path.join(outputDir2, board_filename), "w") as fout2:
                 fout2.write(stdout)
         else:
-            shutil.copyfile(prjct_name, os.path.join(outputDir2, prjct_name))
+            shutil.copyfile(board_filename, os.path.join(outputDir2, board_filename))
 
-        print("")
-        print("Check datetime")
-
-        if not diff1 == prjct_name:
+        if not commit1 == board_filename:
             gitDateTime1 = ["git", "show", "-s", '--format="%ci"', artifact1]
-            print(' '.join(gitDateTime1))
 
-        if not diff2 == prjct_name:
+        if not commit2 == board_filename:
             gitDateTime2 = ["git", "show", "-s", '--format="%ci"', artifact2]
-            print(' '.join(gitDateTime2))
 
-        if not diff1 == prjct_name:
-            stdout, stderr = settings.run_cmd(prjct_path, gitDateTime1)
+        if not commit1 == board_filename:
+            stdout, stderr = settings.run_cmd(repo_path, gitDateTime1)
             dateTime1 = stdout
             date1, time1, UTC = dateTime1.split(" ")
             time1 = date1 + " " + time1
         else:
-            artifact1 = prjct_name
-            modTimesinceEpoc = os.path.getmtime(prjct_name)
+            artifact1 = board_filename
+            modTimesinceEpoc = os.path.getmtime(board_filename)
             time1 = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(modTimesinceEpoc))
 
-        if not diff2 == prjct_name:
-            stdout, stderr = settings.run_cmd(prjct_path, gitDateTime2)
+        if not commit2 == board_filename:
+            stdout, stderr = settings.run_cmd(repo_path, gitDateTime2)
             dateTime2 = stdout
             date2, time2, UTC = dateTime2.split(" ")
             time2 = date2 + " " + time2
         else:
-            artifact2 = prjct_name
-            modTimesinceEpoc = os.path.getmtime(prjct_name)
+            artifact2 = board_filename
+            modTimesinceEpoc = os.path.getmtime(board_filename)
             time2 = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(modTimesinceEpoc))
 
         return artifact1, artifact2, time1 + " " + time2
 
     @staticmethod
-    def get_artefacts(prjct_path, kicad_project_path, board_file):
+    def get_artefacts(repo_path, kicad_project_dir, board_file):
         """Returns list of artifacts from a directory"""
 
         cmd = [
@@ -126,24 +108,24 @@ class scm(generic_scm):
             "log",
             "--date=local",
             "--pretty=format:%h | %ai | %an | %s",
-            os.path.join(kicad_project_path, board_file),
+            os.path.join(kicad_project_dir, board_file),
         ]
 
-        stdout, _ = settings.run_cmd(prjct_path, cmd)
+        stdout, _ = settings.run_cmd(repo_path, cmd)
 
         artifacts = [board_file] + stdout.splitlines()
 
         return artifacts
 
     @staticmethod
-    def get_kicad_project_path(prjct_path):
+    def split_repo_path(kicad_project_path):
         """Returns the root folder of the repository"""
 
         cmd = ["git", "rev-parse", "--show-toplevel"]
 
-        stdout, _ = settings.run_cmd(prjct_path, cmd)
-        repo_root_path = stdout.strip()
+        stdout, _ = settings.run_cmd(kicad_project_path, cmd)
+        repo_path = stdout.strip()
 
-        kicad_project_path = os.path.relpath(prjct_path, repo_root_path)
+        kicad_project_dir = os.path.relpath(kicad_project_path, repo_path)
 
-        return repo_root_path, kicad_project_path
+        return repo_path, kicad_project_dir

--- a/scms/git.py
+++ b/scms/git.py
@@ -9,7 +9,7 @@ from scms.generic import scm as generic_scm
 class scm(generic_scm):
 
     @staticmethod
-    def get_boards(repo_path, kicad_project_dir, board_filename, commit1, commit2):
+    def get_boards(kicad_pcb_path, repo_path, kicad_project_dir, board_filename, commit1, commit2):
         """Given two git artifacts, write out two kicad_pcb files to their respective
         directories (named after the artifact). Returns the date and time of both commits"""
 
@@ -62,14 +62,14 @@ class scm(generic_scm):
             with open(os.path.join(outputDir1, board_filename), "w") as fout1:
                 fout1.write(stdout)
         else:
-            shutil.copyfile(board_filename, os.path.join(outputDir1, board_filename))
+            shutil.copyfile(kicad_pcb_path, os.path.join(outputDir1, board_filename))
 
         if not commit2 == board_filename:
             stdout, stderr = settings.run_cmd(repo_path, gitArtifact2)
             with open(os.path.join(outputDir2, board_filename), "w") as fout2:
                 fout2.write(stdout)
         else:
-            shutil.copyfile(board_filename, os.path.join(outputDir2, board_filename))
+            shutil.copyfile(kicad_pcb_path, os.path.join(outputDir2, board_filename))
 
         if not commit1 == board_filename:
             gitDateTime1 = ["git", "show", "-s", '--format="%ci"', artifact1]
@@ -84,7 +84,7 @@ class scm(generic_scm):
             time1 = date1 + " " + time1
         else:
             artifact1 = board_filename
-            modTimesinceEpoc = os.path.getmtime(board_filename)
+            modTimesinceEpoc = os.path.getmtime(kicad_pcb_path)
             time1 = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(modTimesinceEpoc))
 
         if not commit2 == board_filename:
@@ -94,7 +94,7 @@ class scm(generic_scm):
             time2 = date2 + " " + time2
         else:
             artifact2 = board_filename
-            modTimesinceEpoc = os.path.getmtime(board_filename)
+            modTimesinceEpoc = os.path.getmtime(kicad_pcb_path)
             time2 = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(modTimesinceEpoc))
 
         return artifact1, artifact2, time1 + " " + time2

--- a/scms/svn.py
+++ b/scms/svn.py
@@ -51,13 +51,13 @@ class scm(generic_scm):
                 print("\nThere is no difference in .kicad_pcb file in selected commits")
 
         outputDir1 = os.path.join(
-            prjct_path, settings.plot_dir, kicad_project_path, artifact1
+            prjct_path, settings.output_dir, kicad_project_path, artifact1
         )
         if not os.path.exists(outputDir1):
             os.makedirs(outputDir1)
 
         outputDir2 = os.path.join(
-            prjct_path, settings.plot_dir, kicad_project_path, artifact2
+            prjct_path, settings.output_dir, kicad_project_path, artifact2
         )
         if not os.path.exists(outputDir2):
             os.makedirs(outputDir2)

--- a/scms/svn.py
+++ b/scms/svn.py
@@ -11,7 +11,7 @@ from dateutil.parser import isoparse
 class scm(generic_scm):
 
     @staticmethod
-    def get_boards(repo_path, kicad_project_dir, board_filename, commit1, commit2):
+    def get_boards(kicad_pcb_path, repo_path, kicad_project_dir, board_filename, commit1, commit2):
         """Given two SVN revisions, write out two kicad_pcb files to their respective
         directories (named after the revision number). Returns the date and time of both commits"""
 
@@ -72,14 +72,14 @@ class scm(generic_scm):
             with open(os.path.join(outputDir1, board_filename), "w") as fout1:
                 fout1.write(stdout)
         else:
-            shutil.copyfile(board_filename, os.path.join(outputDir1, board_filename))
+            shutil.copyfile(kicad_pcb_path, os.path.join(outputDir1, board_filename))
 
         if not commit2 == board_filename:
             stdout, stderr = settings.run_cmd(repo_path, svnArtifact2)
             with open(os.path.join(outputDir2, board_filename), "w") as fout2:
                 fout2.write(stdout)
         else:
-            shutil.copyfile(board_filename, os.path.join(outputDir2, board_filename))
+            shutil.copyfile(kicad_pcb_path, os.path.join(outputDir2, board_filename))
 
         if not commit1 == board_filename:
             svnDateTime1 = ["svn", "log", "-r", artifact1]
@@ -95,7 +95,7 @@ class scm(generic_scm):
             _, SVNdate1, SVNtime1, SVNutc, *_ = cmt[2].split(" ")
         else:
             artifact1 = board_filename
-            modTimesinceEpoc = os.path.getmtime(board_filename)
+            modTimesinceEpoc = os.path.getmtime(kicad_pcb_path)
             SVNdate1 = time.strftime("%Y-%m-%d", time.localtime(modTimesinceEpoc))
             SVNtime1 = time.strftime("%H:%M:%S", time.localtime(modTimesinceEpoc))
 
@@ -107,7 +107,7 @@ class scm(generic_scm):
             _, SVNdate2, SVNtime2, SVNutc, *_ = cmt[2].split(" ")
         else:
             artifact2 = board_filename
-            modTimesinceEpoc = os.path.getmtime(board_filename)
+            modTimesinceEpoc = os.path.getmtime(kicad_pcb_path)
             SVNdate2 = time.strftime("%Y-%m-%d", time.localtime(modTimesinceEpoc))
             SVNtime2 = time.strftime("%H:%M:%S", time.localtime(modTimesinceEpoc))
 

--- a/settings.py
+++ b/settings.py
@@ -46,7 +46,7 @@ def run_cmd(exec_path: str, cmd: List[str]) -> Tuple[str, str]:
     if verbose > 1:
         print("")
         print(bcolors.WARNING + "Path:", exec_path + bcolors.ENDC)
-        print(bcolors.WARNING + " Cmd:", " ".join(cmd) + bcolors.ENDC)
+        print(bcolors.WARNING + " Cmd:", bcolors.OKBLUE + " ".join(cmd) + bcolors.ENDC)
 
     p = Popen(
         cmd,
@@ -60,5 +60,11 @@ def run_cmd(exec_path: str, cmd: List[str]) -> Tuple[str, str]:
 
     stdout, stderr = p.communicate()
     p.wait()
+
+    if verbose > 3:
+        print(bcolors.OKCYAN + stdout + bcolors.ENDC)
+
+    if verbose > 1:
+        print(bcolors.FAIL + stderr + bcolors.ENDC)
 
     return stdout.strip("\n "), stderr

--- a/settings.py
+++ b/settings.py
@@ -59,12 +59,19 @@ def run_cmd(exec_path: str, cmd: List[str]) -> Tuple[str, str]:
     )
 
     stdout, stderr = p.communicate()
-    p.wait()
+    ret = p.wait()
 
     if verbose > 3:
         print(bcolors.OKCYAN + stdout + bcolors.ENDC)
 
-    if verbose > 1:
+    if verbose > 2:
         print(bcolors.FAIL + stderr + bcolors.ENDC)
+
+    if verbose > 1:
+        if ret == 0:
+            print(bcolors.OKGREEN + "Code:", str(ret) + bcolors.ENDC)
+        else:
+            print(bcolors.FAIL + "Code:", str(ret) + bcolors.ENDC)
+
 
     return stdout.strip("\n "), stderr

--- a/settings.py
+++ b/settings.py
@@ -5,6 +5,8 @@ from typing import List, Tuple
 
 args = ""
 
+global verbose
+
 global gitProg
 global fossilProg
 global svnProg
@@ -16,6 +18,8 @@ global plot_prog
 global output_dir
 global web_dir
 
+verbose = 0
+
 gitProg = "git"
 fossilProg = "fossil"
 svnProg = "svn"
@@ -26,8 +30,23 @@ plot_prog = "plotpcb"
 
 web_dir = "web"
 
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
 
-def run_cmd(path: str, cmd: List[str]) -> Tuple[str, str]:
+def run_cmd(exec_path: str, cmd: List[str]) -> Tuple[str, str]:
+
+    if verbose > 1:
+        print("")
+        print(bcolors.WARNING + "Path:", exec_path + bcolors.ENDC)
+        print(bcolors.WARNING + " Cmd:", " ".join(cmd) + bcolors.ENDC)
 
     p = Popen(
         cmd,
@@ -36,7 +55,7 @@ def run_cmd(path: str, cmd: List[str]) -> Tuple[str, str]:
         stderr=PIPE,
         close_fds=True,
         encoding="utf-8",
-        cwd=path,
+        cwd=exec_path,
     )
 
     stdout, stderr = p.communicate()

--- a/settings.py
+++ b/settings.py
@@ -24,7 +24,6 @@ grepProg = "grep"
 
 plot_prog = "plotpcb"
 
-# output_dir = "kidiff"
 web_dir = "web"
 
 

--- a/settings.py
+++ b/settings.py
@@ -13,7 +13,7 @@ global grepProg
 
 global plot_prog
 
-global plot_dir
+global output_dir
 global web_dir
 
 gitProg = "git"
@@ -24,7 +24,7 @@ grepProg = "grep"
 
 plot_prog = "plotpcb"
 
-plot_dir = "kidiff"
+# output_dir = "kidiff"
 web_dir = "web"
 
 

--- a/tkUI.py
+++ b/tkUI.py
@@ -28,12 +28,12 @@ PROJECT_UI = os.path.join(PROJECT_PATH, "kidiff.ui")
 
 
 class KidiffApp:
-    def __init__(self, artifacts, prjctName, kicad_project_path, prjctPath, scm):
+    def __init__(self, repo_path, kicad_project_dir, board_filename, scm, scm_artifacts):
 
-        self.artifacts = artifacts
-        self.prjctName = prjctName
-        self.kicad_project_path = kicad_project_path
-        self.prjctPath = prjctPath
+        self.scm_artifacts = scm_artifacts
+        self.board_filename = board_filename
+        self.kicad_project_dir = kicad_project_dir
+        self.repo_path = repo_path
         self.scm = scm
 
         self.builder = builder = pygubu.Builder()
@@ -47,7 +47,7 @@ class KidiffApp:
 
         self.set_repo_info()
         self.set_repo_path()
-        self.fill_artifacts()
+        self.fill_scm_artifacts()
 
         self.commit1 = ""
         self.commit2 = ""
@@ -83,14 +83,12 @@ class KidiffApp:
 
     def set_repo_path(self):
 
-        if self.kicad_project_path == ".":
-            board_path = self.prjctPath + "/" + self.prjctName
+        if self.kicad_project_dir == ".":
+            board_path = os.path.join(self.repo_path, self.board_filename)
         else:
             board_path = (
-                self.prjctPath + "/" + self.kicad_project_path + "/" + self.prjctName
+                os.path.join(self.repo_path, self.kicad_project_dir, self.board_filename)
             )
-
-        board_path = board_path.replace("//", "/")
 
         self.board_path = self.builder.get_object("board_path")
         self.board_path["text"] = board_path
@@ -105,7 +103,7 @@ class KidiffApp:
     def update_commit2(self, event):
         self.commit2 = self.listbox_2.get(self.listbox_2.curselection())
 
-    def fill_artifacts(self):
+    def fill_scm_artifacts(self):
 
         self.listbox_1 = self.builder.get_object("listbox_1")
         self.listbox_2 = self.builder.get_object("listbox_2")
@@ -113,8 +111,8 @@ class KidiffApp:
         self.listbox_1.bind("<<ListboxSelect>>", self.update_commit1)
         self.listbox_2.bind("<<ListboxSelect>>", self.update_commit2)
 
-        # Fill artifacts
-        for i, line in enumerate(self.artifacts):
+        # Fill scm_artifacts
+        for i, line in enumerate(self.scm_artifacts):
             self.listbox_1.insert(END, line)
             self.listbox_2.insert(END, line)
 
@@ -128,14 +126,14 @@ class KidiffApp:
                 )
 
         # Commit set on first commit by default
-        if len(self.artifacts) >= 1:
+        if len(self.scm_artifacts) >= 1:
 
             self.listbox_1.select_set(0)  # This only sets focus
             self.listbox_1.event_generate("<<ListboxSelect>>")
             self.commit1 = self.listbox_1.get(self.listbox_1.curselection())
 
             # Commit set on the second commit by default
-            if len(self.artifacts) >= 2:
+            if len(self.scm_artifacts) >= 2:
                 self.listbox_2.select_set(1)  # This only sets focus
                 self.listbox_2.event_generate("<<ListboxSelect>>")
                 self.commit2 = self.listbox_2.get(self.listbox_2.curselection())
@@ -152,8 +150,8 @@ class KidiffApp:
         self.main_window.mainloop()
 
 
-def runGUI(artifacts, prjctName, kicad_project_path, prjctPath, scm):
+def runGUI(repo_path, kicad_project_dir, board_filename, scm, scm_artifacts):
 
-    app = KidiffApp(artifacts, prjctName, kicad_project_path, prjctPath, scm)
+    app = KidiffApp(repo_path, kicad_project_dir, board_filename, scm, scm_artifacts)
     app.run()
     return app.commit1, app.commit2


### PR DESCRIPTION
Hi @Gasman2014 I am adding a command line parameter to be able to specify the output folder

The current folder is being generated inside of the repository with `kidiff` as a fixed name 

This PR improves it in a way that we can set it as the user wishes. It also allows the generation of it outside of the repo. For instance, it is possible now to generate this inside the `/tmp` folder. 

This is an example of the command to do that.

```
kidiff board.kicad_pcb -o /tmp/my_kidiff_folder
```
